### PR TITLE
fix(chatgpt): remove webpage citation pills from copied markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- ChatGPT: Webpage citation pills are now removed from copied and exported message content, including their visible domain labels, grouped-source counts, and hidden links.
+
 ## [4.2.3] - 2026-04-29
 
 ### Added

--- a/src/drivers/content/adapters/sites/chatgpt.ts
+++ b/src/drivers/content/adapters/sites/chatgpt.ts
@@ -325,6 +325,21 @@ export class ChatGPTAdapter extends SiteAdapter {
         return !!stopButton;
     }
 
+    normalizeDOM(root: HTMLElement): void {
+        root.querySelectorAll('[data-testid="webpage-citation-pill"]').forEach((pill) => {
+            const wrapper = pill.parentElement;
+            pill.remove();
+
+            if (
+                wrapper instanceof HTMLElement &&
+                wrapper.matches('span[data-state]') &&
+                wrapper.childNodes.length === 0
+            ) {
+                wrapper.remove();
+            }
+        });
+    }
+
     cleanMarkdown(markdown: string): string {
         return cleanChatGPTReferenceNoise(markdown);
     }

--- a/tests/unit/services/copy/copy-markdown.contract.test.ts
+++ b/tests/unit/services/copy/copy-markdown.contract.test.ts
@@ -111,4 +111,28 @@ describe('copyMarkdownFromMessage adapter contract', () => {
         expect(result.markdown).not.toContain('https://example.com');
         expect(result.markdown).not.toContain('Sources');
     });
+
+    it('removes ChatGPT webpage citation pills and their empty state wrapper', () => {
+        document.body.innerHTML = `
+          <div data-message-author-role="assistant" data-message-id="a1">
+            <div class="markdown prose">
+<p>Useful answer<span data-state="closed"><span data-testid="webpage-citation-pill"><a href="https://github.blog/changelog/2026-03-25-updates-to-our-privacy-statement-and-terms-of-service-how-we-use-your-data/"><span>github.blog</span><span>+2</span></a></span></span> continues.</p>
+            </div>
+          </div>
+        `;
+
+        const adapter = new ChatGPTAdapter();
+        const message = document.querySelector(adapter.getMessageSelector());
+        expect(message).toBeInstanceOf(HTMLElement);
+        if (!(message instanceof HTMLElement)) return;
+
+        const result = copyMarkdownFromMessage(adapter, message);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        expect(result.markdown).toBe('Useful answer continues.');
+        expect(result.markdown).not.toContain('github.blog');
+        expect(result.markdown).not.toContain('+2');
+        expect(result.markdown).not.toContain('https://github.blog');
+    });
 });


### PR DESCRIPTION
## Summary
- Remove ChatGPT `webpage-citation-pill` controls from cloned message DOM before Markdown parsing.
- Drop the now-empty direct `span[data-state]` wrapper when the citation pill was its only child.
- Add regression coverage so citation pill display text, aggregate counts, and hrefs do not leak into copied Markdown.

## Scope
This change only targets elements with `data-testid="webpage-citation-pill"` and their empty direct wrapper.
It does not change the existing Markdown link cleanup behavior, table serialization, Reader rendering, or broader citation/source cleanup rules.

## Test scenario:
<img width="1299" height="786" alt="image" src="https://github.com/user-attachments/assets/1680f43d-1314-4d32-850b-be14115b4a7f" />

## Before:
<img width="1353" height="1080" alt="image" src="https://github.com/user-attachments/assets/2e6ceac0-9e35-491a-b1c5-ce76bad5bfbd" />

## After:
<img width="1343" height="1071" alt="image" src="https://github.com/user-attachments/assets/b64af363-aa5e-4de8-835c-445c28860a10" />
