### PR TITLE
Improve PNG copy and export progress handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to AI-MarkDone will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Export: Copy as PNG now replaces the generic working status with a progress panel that shows render progress and a cancel button.
+- Export: Save Messages PNG export now shows both the current message render progress and the total export progress while exporting multiple messages.
+
+### Changed
+- Export: Copy as PNG and Save Messages PNG export now split dense rendered content by DOM complexity as well as height, reducing long browser stalls on messages with many formulas, code blocks, tables, or images.
+
+### Fixed
+- Export: Closing the Save Messages dialog during PNG export now cancels the in-progress export instead of only hiding the dialog.
+
 ## [4.3.1] - 2026-05-07
 
 ### Fixed

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -27,6 +27,10 @@
         "message": "PNG downloaded",
         "description": "Message for btnCopyAsPngDownloaded"
     },
+    "copyPngCancelled": {
+        "message": "PNG copy cancelled",
+        "description": "Message shown when Copy as PNG is cancelled"
+    },
     "formulaCopyAsPng": {
         "message": "Copy as PNG",
         "description": "Message for formulaCopyAsPng"
@@ -494,6 +498,50 @@
     "pngExportDone": {
         "message": "PNG export ready $1",
         "description": "Message for pngExportDone"
+    },
+    "pngExportCancelled": {
+        "message": "PNG export cancelled",
+        "description": "Message shown when PNG export is cancelled"
+    },
+    "pngExportCurrentProgressLabel": {
+        "message": "Current message",
+        "description": "Accessible label for the current PNG message progress bar"
+    },
+    "pngExportTotalProgressLabel": {
+        "message": "Total export",
+        "description": "Accessible label for the total PNG export progress bar"
+    },
+    "pngExportCurrentPreparing": {
+        "message": "Current message $1",
+        "description": "Message for current PNG preparation progress"
+    },
+    "pngExportCurrentPreparingWithFilename": {
+        "message": "Current message $1: $2",
+        "description": "Message for current PNG preparation progress with filename"
+    },
+    "pngExportCurrentRendering": {
+        "message": "Current message $1",
+        "description": "Message for current PNG rendering progress"
+    },
+    "pngExportCurrentRenderingWithFilename": {
+        "message": "Current message $1: $2",
+        "description": "Message for current PNG rendering progress with filename"
+    },
+    "pngExportCurrentEncoding": {
+        "message": "Encoding current message",
+        "description": "Message for current PNG encoding progress"
+    },
+    "pngExportCurrentEncodingWithFilename": {
+        "message": "Encoding current message: $1",
+        "description": "Message for current PNG encoding progress with filename"
+    },
+    "pngExportCurrentDone": {
+        "message": "Current message ready",
+        "description": "Message for current PNG completion progress"
+    },
+    "pngExportCurrentDoneWithFilename": {
+        "message": "Current message ready: $1",
+        "description": "Message for current PNG completion progress with filename"
     },
     "pngExportWidthPresetLabel": {
         "message": "PNG image width",

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -27,6 +27,10 @@
         "message": "PNG 已下载",
         "description": "Message for btnCopyAsPngDownloaded"
     },
+    "copyPngCancelled": {
+        "message": "PNG 复制已取消",
+        "description": "Message shown when Copy as PNG is cancelled"
+    },
     "formulaCopyAsPng": {
         "message": "复制为PNG",
         "description": "Message for formulaCopyAsPng"
@@ -494,6 +498,50 @@
     "pngExportDone": {
         "message": "PNG 导出已完成 $1",
         "description": "Message for pngExportDone"
+    },
+    "pngExportCancelled": {
+        "message": "PNG 导出已取消",
+        "description": "Message shown when PNG export is cancelled"
+    },
+    "pngExportCurrentProgressLabel": {
+        "message": "当前消息",
+        "description": "Accessible label for the current PNG message progress bar"
+    },
+    "pngExportTotalProgressLabel": {
+        "message": "总进度",
+        "description": "Accessible label for the total PNG export progress bar"
+    },
+    "pngExportCurrentPreparing": {
+        "message": "当前消息 $1",
+        "description": "Message for current PNG preparation progress"
+    },
+    "pngExportCurrentPreparingWithFilename": {
+        "message": "当前消息 $1：$2",
+        "description": "Message for current PNG preparation progress with filename"
+    },
+    "pngExportCurrentRendering": {
+        "message": "当前消息 $1",
+        "description": "Message for current PNG rendering progress"
+    },
+    "pngExportCurrentRenderingWithFilename": {
+        "message": "当前消息 $1：$2",
+        "description": "Message for current PNG rendering progress with filename"
+    },
+    "pngExportCurrentEncoding": {
+        "message": "正在编码当前消息",
+        "description": "Message for current PNG encoding progress"
+    },
+    "pngExportCurrentEncodingWithFilename": {
+        "message": "正在编码当前消息：$1",
+        "description": "Message for current PNG encoding progress with filename"
+    },
+    "pngExportCurrentDone": {
+        "message": "当前消息已就绪",
+        "description": "Message for current PNG completion progress"
+    },
+    "pngExportCurrentDoneWithFilename": {
+        "message": "当前消息已就绪：$1",
+        "description": "Message for current PNG completion progress with filename"
     },
     "pngExportWidthPresetLabel": {
         "message": "PNG 图片宽度",

--- a/src/drivers/content/export/renderControl.ts
+++ b/src/drivers/content/export/renderControl.ts
@@ -1,0 +1,34 @@
+export type RenderProgressEvent = {
+    phase: 'preparing' | 'loading_assets' | 'rendering' | 'rendering_chunk' | 'stitching' | 'encoding' | 'done';
+    completed?: number;
+    total?: number;
+};
+
+export class RenderAbortError extends Error {
+    constructor(message = 'Operation cancelled.') {
+        super(message);
+        this.name = 'AbortError';
+    }
+}
+
+export function throwIfAborted(signal?: AbortSignal): void {
+    if (!signal?.aborted) return;
+    throw new RenderAbortError();
+}
+
+export function isRenderAbortError(error: unknown): boolean {
+    return error instanceof RenderAbortError
+        || (typeof error === 'object' && error !== null && (error as { name?: unknown }).name === 'AbortError');
+}
+
+export async function yieldToBrowser(signal?: AbortSignal): Promise<void> {
+    throwIfAborted(signal);
+    await new Promise<void>((resolve) => {
+        if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(() => resolve());
+            return;
+        }
+        window.setTimeout(resolve, 0);
+    });
+    throwIfAborted(signal);
+}

--- a/src/drivers/content/export/renderPng.ts
+++ b/src/drivers/content/export/renderPng.ts
@@ -1,6 +1,7 @@
 import { toCanvas } from 'html-to-image';
 import { logger } from '../../../core/logger';
 import { getKatexCssWithEmbeddedFonts, type KatexEmbeddedCssResult } from './katexAssets';
+import { isRenderAbortError, throwIfAborted, yieldToBrowser, type RenderProgressEvent } from './renderControl';
 
 export type RenderPngMetrics = {
     width: number;
@@ -24,6 +25,8 @@ export type RenderPngPlan = {
     backgroundColor: string;
     imageTimeoutMs?: number;
     onMetrics?: (metrics: RenderPngMetrics) => void;
+    onProgress?: (event: RenderProgressEvent) => void;
+    signal?: AbortSignal;
 };
 
 type PixelRatioResult = {
@@ -38,8 +41,18 @@ const SAFE_CANVAS_PIXEL_AREA_LIMIT = 24_000_000;
 const CHUNK_HEIGHT_TRIGGER = 2000;
 const MAX_CHUNK_HEIGHT = 2000;
 const TARGET_CHUNK_HEIGHT = 2000;
+const TARGET_CHUNK_NODE_COUNT = 900;
+const TARGET_CHUNK_COMPLEX_NODE_COUNT = 120;
+const TARGET_CHUNK_TEXT_CHARS = 16000;
 const IMAGE_PLACEHOLDER_DATA_URL =
     'data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%22640%22 height=%22320%22 viewBox=%220 0 640 320%22%3E%3Crect width=%22640%22 height=%22320%22 rx=%2216%22 fill=%22%23f6f8fa%22/%3E%3Crect x=%221%22 y=%221%22 width=%22638%22 height=%22318%22 rx=%2215%22 fill=%22none%22 stroke=%22%23d0d7de%22/%3E%3Ctext x=%22320%22 y=%22162%22 text-anchor=%22middle%22 font-family=%22Arial,sans-serif%22 font-size=%2220%22 fill=%22%2357606a%22%3EImage unavailable%3C/text%3E%3C/svg%3E';
+
+type BlockCost = {
+    height: number;
+    nodes: number;
+    complexNodes: number;
+    textChars: number;
+};
 
 function createRoot(): HTMLElement {
     document.getElementById(ROOT_ID)?.remove();
@@ -143,23 +156,67 @@ function collectChunkBlocks(node: HTMLElement): HTMLElement[] {
     return Array.from(card.children).filter((child): child is HTMLElement => child instanceof HTMLElement);
 }
 
+function estimateBlockCost(block: HTMLElement, fallbackHeight: number): BlockCost {
+    const descendants = Array.from(block.querySelectorAll('*'));
+    const complexNodes = descendants.filter((node) => {
+        if (!(node instanceof Element)) return false;
+        return node.matches([
+            'img',
+            'svg',
+            'canvas',
+            'table',
+            'thead',
+            'tbody',
+            'tr',
+            'td',
+            'th',
+            'pre',
+            'code',
+            '.reader-code-block',
+            '.reader-code-block *',
+            '.katex',
+            '.katex *',
+            'mjx-container',
+            'mjx-container *',
+        ].join(','));
+    }).length;
+    return {
+        height: readElementHeight(block, fallbackHeight),
+        nodes: descendants.length + 1,
+        complexNodes,
+        textChars: block.textContent?.length ?? 0,
+    };
+}
+
+function wouldExceedChunkBudget(current: BlockCost, next: BlockCost): boolean {
+    // Low-height content can still stall html-to-image when rich DOM nodes pile up.
+    return current.height + next.height > TARGET_CHUNK_HEIGHT
+        || current.nodes + next.nodes > TARGET_CHUNK_NODE_COUNT
+        || current.complexNodes + next.complexNodes > TARGET_CHUNK_COMPLEX_NODE_COUNT
+        || current.textChars + next.textChars > TARGET_CHUNK_TEXT_CHARS;
+}
+
 function groupBlocks(blocks: HTMLElement[], totalHeight: number): HTMLElement[][] {
     if (blocks.length === 0) return [];
-    const measured = blocks.map((block) => readElementHeight(block, 0));
     const fallbackHeight = Math.max(1, Math.ceil(totalHeight / blocks.length));
-    const heights = measured.map((height) => height > 0 ? height : fallbackHeight);
+    const costs = blocks.map((block) => estimateBlockCost(block, fallbackHeight));
     const groups: HTMLElement[][] = [];
     let current: HTMLElement[] = [];
-    let currentHeight = 0;
+    let currentCost: BlockCost = { height: 0, nodes: 0, complexNodes: 0, textChars: 0 };
     blocks.forEach((block, index) => {
-        const height = heights[index] ?? fallbackHeight;
-        if (current.length > 0 && currentHeight + height > TARGET_CHUNK_HEIGHT) {
+        const cost = costs[index] ?? estimateBlockCost(block, fallbackHeight);
+        if (current.length > 0 && wouldExceedChunkBudget(currentCost, cost)) {
             groups.push(current);
             current = [];
-            currentHeight = 0;
+            currentCost = { height: 0, nodes: 0, complexNodes: 0, textChars: 0 };
         }
         current.push(block);
-        currentHeight += height;
+        currentCost = {
+            height: currentCost.height + cost.height,
+            nodes: currentCost.nodes + cost.nodes,
+            complexNodes: currentCost.complexNodes + cost.complexNodes,
+            textChars: currentCost.textChars + cost.textChars,
+        };
     });
     if (current.length > 0) groups.push(current);
     return groups;
@@ -212,17 +269,25 @@ async function renderChunkedCanvas(sourceNode: HTMLElement, plan: RenderPngPlan,
 
     const canvases: HTMLCanvasElement[] = [];
     for (let index = 0; index < groups.length; index += 1) {
+        throwIfAborted(plan.signal);
+        plan.onProgress?.({ phase: 'rendering_chunk', completed: index, total: groups.length });
+        await yieldToBrowser(plan.signal);
         const chunkNode = buildChunkNode(sourceNode, groups[index]!, index);
         sourceNode.parentElement?.appendChild(chunkNode);
         try {
             await waitForImages(chunkNode, plan.imageTimeoutMs ?? DEFAULT_IMAGE_TIMEOUT_MS);
             replaceUnavailableImages(chunkNode);
             canvases.push(await renderNodeToCanvas(chunkNode, plan, pixelRatio, fontEmbed));
+            plan.onProgress?.({ phase: 'rendering_chunk', completed: index + 1, total: groups.length });
+            await yieldToBrowser(plan.signal);
         } finally {
             chunkNode.remove();
         }
     }
 
+    throwIfAborted(plan.signal);
+    plan.onProgress?.({ phase: 'stitching', completed: groups.length, total: groups.length });
+    await yieldToBrowser(plan.signal);
     const width = Math.max(...canvases.map((canvas) => canvas.width));
     const height = canvases.reduce((sum, canvas) => sum + canvas.height, 0);
     if (width > SAFE_CANVAS_DIMENSION_LIMIT || height > SAFE_CANVAS_DIMENSION_LIMIT) {
@@ -252,6 +317,8 @@ function injectKatexCss(node: HTMLElement, fontEmbed: KatexEmbeddedCssResult): v
 }
 
 export async function renderPngBlob(plan: RenderPngPlan): Promise<Blob> {
+    throwIfAborted(plan.signal);
+    plan.onProgress?.({ phase: 'preparing' });
     const root = createRoot();
     const node = document.createElement('div');
     node.style.width = `${plan.width}px`;
@@ -262,9 +329,14 @@ export async function renderPngBlob(plan: RenderPngPlan): Promise<Blob> {
     try {
         const fontEmbed = await getKatexCssWithEmbeddedFonts(plan.html);
         injectKatexCss(node, fontEmbed);
+        await yieldToBrowser(plan.signal);
+        plan.onProgress?.({ phase: 'loading_assets' });
         await waitForFonts();
+        throwIfAborted(plan.signal);
         await waitForImages(node, plan.imageTimeoutMs ?? DEFAULT_IMAGE_TIMEOUT_MS);
+        throwIfAborted(plan.signal);
         replaceUnavailableImages(node);
+        await yieldToBrowser(plan.signal);
         const exportWidth = node.scrollWidth || plan.width;
         const exportHeight = node.scrollHeight;
         const { effectivePixelRatio, capReason } = resolveSafePixelRatio(plan.pixelRatio, exportWidth, exportHeight);
@@ -285,9 +357,15 @@ export async function renderPngBlob(plan: RenderPngPlan): Promise<Blob> {
         }
 
         const strategy = exportHeight > CHUNK_HEIGHT_TRIGGER ? 'chunked' : 'single';
+        plan.onProgress?.({ phase: 'rendering', completed: 0, total: strategy === 'chunked' ? undefined : 1 });
+        await yieldToBrowser(plan.signal);
         const rendered = strategy === 'chunked'
             ? await renderChunkedCanvas(node, plan, effectivePixelRatio, fontEmbed, exportHeight)
             : { canvas: await renderNodeToCanvas(node, plan, effectivePixelRatio, fontEmbed), chunkCount: 1 };
+        throwIfAborted(plan.signal);
+        if (strategy === 'single') {
+            plan.onProgress?.({ phase: 'rendering', completed: 1, total: 1 });
+        }
         plan.onMetrics?.({
             width: exportWidth,
             height: exportHeight,
@@ -301,8 +379,14 @@ export async function renderPngBlob(plan: RenderPngPlan): Promise<Blob> {
             maxChunkHeight: strategy === 'chunked' ? MAX_CHUNK_HEIGHT : undefined,
             fontEmbedMode: fontEmbed.mode,
         });
-        return await canvasToBlob(rendered.canvas);
+        plan.onProgress?.({ phase: 'encoding' });
+        await yieldToBrowser(plan.signal);
+        const blob = await canvasToBlob(rendered.canvas);
+        throwIfAborted(plan.signal);
+        plan.onProgress?.({ phase: 'done' });
+        return blob;
     } catch (err: any) {
+        if (isRenderAbortError(err)) throw err;
         if (err?.message?.startsWith('PNG export failed')) throw err;
         const exportWidth = node.scrollWidth || plan.width;
         const exportHeight = node.scrollHeight;

--- a/src/services/copy/copy-turn-png.ts
+++ b/src/services/copy/copy-turn-png.ts
@@ -1,13 +1,14 @@
 import { copyImageBlobToClipboard } from '../../drivers/content/clipboard/copyImageToClipboard';
 import { downloadBlob } from '../../drivers/content/export/downloadBlob';
 import { renderPngBlob, type RenderPngMetrics } from '../../drivers/content/export/renderPng';
+import { isRenderAbortError, throwIfAborted, type RenderProgressEvent } from '../../drivers/content/export/renderControl';
 import { buildPngExportPlans, type BuildPngExportPlanOptions } from '../export/saveMessagesPng';
 import type { ChatTurn, ConversationMetadata, TranslateFn } from '../export/saveMessagesTypes';
 import { nowMs, type CopyPngDebugSink } from './copy-png-debug';
 
 export type CopyTurnsPngResult =
     | { ok: true; noop: boolean; fallback?: 'download' }
-    | { ok: false; error: { code: string; message: string } };
+    | { ok: false; error: { code: string; message: string }; cancelled?: boolean };
 
 export async function copyTurnsPng(
     turns: ChatTurn[],
@@ -17,6 +18,8 @@ export async function copyTurnsPng(
         t: TranslateFn;
         png?: BuildPngExportPlanOptions;
         onDebug?: CopyPngDebugSink;
+        onProgress?: (event: RenderProgressEvent) => void;
+        signal?: AbortSignal;
     },
 ): Promise<CopyTurnsPngResult> {
     if (!selectedIndices || selectedIndices.length === 0) return { ok: true, noop: true };
@@ -28,6 +31,7 @@ export async function copyTurnsPng(
     });
 
     try {
+        throwIfAborted(options.signal);
         const buildPlanStartedAt = nowMs();
         const result = buildPngExportPlans(turns, selectedIndices, metadata, options.t, options.png);
         if (!result || result.plans.length < 1) return { ok: true, noop: true };
@@ -51,10 +55,13 @@ export async function copyTurnsPng(
         const renderStartedAt = nowMs();
         const blob = await renderPngBlob({
             ...result.plans[0]!,
+            signal: options.signal,
+            onProgress: options.onProgress,
             onMetrics: (metrics) => {
                 renderMetrics = { ...metrics };
             },
         });
+        throwIfAborted(options.signal);
         emit({
             stage: 'render_blob',
             durationMs: Math.round(nowMs() - renderStartedAt),
@@ -73,6 +80,8 @@ export async function copyTurnsPng(
         });
 
         const clipboardStartedAt = nowMs();
+        options.onProgress?.({ phase: 'encoding' });
+        throwIfAborted(options.signal);
         const clipboardResult = await copyImageBlobToClipboard(blob);
         emit({
             stage: 'clipboard_write',
@@ -91,6 +100,7 @@ export async function copyTurnsPng(
             return { ok: true, noop: false };
         }
 
+        throwIfAborted(options.signal);
         if (clipboardResult.reason === 'unsupported') {
             emit({
                 stage: 'copy_error',
@@ -104,6 +114,7 @@ export async function copyTurnsPng(
             };
         }
 
+        throwIfAborted(options.signal);
         downloadBlob({ filename: result.plans[0]!.filename, blob });
         emit({
             stage: 'copy_error',
@@ -113,6 +124,15 @@ export async function copyTurnsPng(
         });
         return { ok: true, noop: false, fallback: 'download' };
     } catch (err: any) {
+        if (isRenderAbortError(err)) {
+            emit({
+                stage: 'copy_error',
+                durationMs: 0,
+                errorCode: 'CANCELLED',
+                errorMessage: options.t('btnCancel'),
+            });
+            return { ok: false, cancelled: true, error: { code: 'CANCELLED', message: options.t('btnCancel') } };
+        }
         emit({
             stage: 'copy_error',
             durationMs: 0,

--- a/src/services/export/saveMessagesFacade.ts
+++ b/src/services/export/saveMessagesFacade.ts
@@ -2,6 +2,7 @@ import { downloadText } from '../../drivers/content/export/downloadFile';
 import { downloadBlob } from '../../drivers/content/export/downloadBlob';
 import { printPdf } from '../../drivers/content/export/printPdf';
 import { renderPngBlob } from '../../drivers/content/export/renderPng';
+import { isRenderAbortError, throwIfAborted } from '../../drivers/content/export/renderControl';
 import { zipBlobs } from '../../drivers/content/export/zipBlobs';
 import type {
     ChatTurn,
@@ -13,12 +14,15 @@ import { buildMarkdownExport } from './saveMessagesMarkdown';
 import { buildPdfPrintPlan } from './saveMessagesPdf';
 import { buildPngExportPlans, type BuildPngExportPlanOptions } from './saveMessagesPng';
 
-export type ExportResult = { ok: true; noop: boolean } | { ok: false; error: { code: string; message: string } };
+export type ExportResult =
+    | { ok: true; noop: boolean }
+    | { ok: false; error: { code: string; message: string }; cancelled?: boolean };
 
 export type ExportOptions = {
     t: TranslateFn;
     png?: BuildPngExportPlanOptions;
     onProgress?: ExportProgressCallback;
+    signal?: AbortSignal;
 };
 
 export async function exportTurnsMarkdown(
@@ -63,14 +67,30 @@ export async function exportTurnsPng(
 ): Promise<ExportResult> {
     if (!selectedIndices || selectedIndices.length === 0) return { ok: true, noop: true };
     try {
+        throwIfAborted(options.signal);
         const result = buildPngExportPlans(turns, selectedIndices, metadata, options.t, options.png);
         if (!result || result.plans.length < 1) return { ok: true, noop: true };
         const total = result.plans.length;
         options.onProgress?.({ phase: 'preparing', completed: 0, total });
+        throwIfAborted(options.signal);
         const files: Array<{ filename: string; blob: Blob }> = [];
         for (const plan of result.plans) {
+            throwIfAborted(options.signal);
             options.onProgress?.({ phase: 'rendering', completed: files.length, total, filename: plan.filename });
-            const blob = await renderPngBlob(plan);
+            const blob = await renderPngBlob({
+                ...plan,
+                signal: options.signal,
+                onProgress: (current) => {
+                    options.onProgress?.({
+                        phase: 'rendering',
+                        completed: files.length,
+                        total,
+                        filename: plan.filename,
+                        current,
+                    });
+                },
+            });
+            throwIfAborted(options.signal);
             files.push({ filename: plan.filename, blob });
             const completed = files.length;
             options.onProgress?.({
@@ -81,18 +101,26 @@ export async function exportTurnsPng(
             });
         }
         if (files.length === 1) {
+            throwIfAborted(options.signal);
             options.onProgress?.({ phase: 'downloading', completed: 1, total, filename: files[0].filename });
+            throwIfAborted(options.signal);
             downloadBlob({ filename: files[0].filename, blob: files[0].blob });
             options.onProgress?.({ phase: 'done', completed: 1, total, filename: files[0].filename });
             return { ok: true, noop: false };
         }
+        throwIfAborted(options.signal);
         options.onProgress?.({ phase: 'zipping', completed: files.length, total, filename: result.zipFilename });
         const zip = await zipBlobs({ files });
+        throwIfAborted(options.signal);
         options.onProgress?.({ phase: 'downloading', completed: files.length, total, filename: result.zipFilename });
+        throwIfAborted(options.signal);
         downloadBlob({ filename: result.zipFilename, blob: zip });
         options.onProgress?.({ phase: 'done', completed: files.length, total, filename: result.zipFilename });
         return { ok: true, noop: false };
     } catch (err: any) {
+        if (isRenderAbortError(err)) {
+            return { ok: false, cancelled: true, error: { code: 'CANCELLED', message: options.t('pngExportCancelled') } };
+        }
         return { ok: false, error: { code: 'INTERNAL_ERROR', message: err?.message || 'Export failed' } };
     }
 }

--- a/src/services/export/saveMessagesTypes.ts
+++ b/src/services/export/saveMessagesTypes.ts
@@ -1,3 +1,5 @@
+import type { RenderProgressEvent } from '../../drivers/content/export/renderControl';
+
 export interface ChatTurn {
     user: string;
     assistant: string; // markdown
@@ -23,6 +25,7 @@ export type ExportProgressEvent = {
     completed: number;
     total: number;
     filename?: string;
+    current?: RenderProgressEvent;
 };
 
 export type ExportProgressCallback = (event: ExportProgressEvent) => void;

--- a/src/ui/content/MessageToolbar.ts
+++ b/src/ui/content/MessageToolbar.ts
@@ -1,11 +1,27 @@
 import type { Theme } from '../../core/types/theme';
 import { getTokenCss } from '../../style/tokens';
 import { ensureStyle } from '../../style/shadow';
+import { xIcon } from '../../assets/icons';
 import { createIcon } from './components/Icon';
 import { t } from './components/i18n';
 import { ToolbarHoverActionPortal } from './components/ToolbarHoverActionPortal';
 
 export type ToolbarActionResult = { ok: true; message?: string } | { ok: false; message: string };
+
+export type ToolbarTaskProgressEvent = {
+    label?: string;
+    completed?: number;
+    total?: number;
+    value?: number | null;
+    indeterminate?: boolean;
+};
+
+export type ToolbarActionContext = {
+    signal: AbortSignal;
+    onProgress: (event: ToolbarTaskProgressEvent) => void;
+};
+
+const TASK_CANCELLED_LABEL = 'Cancelled';
 
 export type MessageToolbarMenuItem = {
     id: string;
@@ -27,7 +43,7 @@ export type MessageToolbarAction = {
         label: string;
         tooltip?: string;
         icon: string;
-        onClick: () => Promise<void | ToolbarActionResult>;
+        onClick: (context?: ToolbarActionContext) => Promise<void | ToolbarActionResult>;
     };
 };
 
@@ -48,6 +64,8 @@ export class MessageToolbar {
     private hoverActionPortalInside = false;
     private toolbarFeedbackTimer: number | null = null;
     private toolbarFeedbackHost: HTMLElement | null = null;
+    private taskProgressTimer: number | null = null;
+    private activeTaskAbort: AbortController | null = null;
 
     constructor(theme: Theme, actions: MessageToolbarAction[], opts?: { showStats?: boolean }) {
         this.theme = theme;
@@ -68,6 +86,7 @@ export class MessageToolbar {
 
     dispose(): void {
         this.clearToolbarFeedback();
+        this.closeTaskProgress();
         this.closeMenu();
         this.closeHoverAction();
         this.hoverActionPortal?.dispose();
@@ -200,6 +219,46 @@ export class MessageToolbar {
         menu.dataset.role = 'menu';
         menu.dataset.open = '0';
         bar.appendChild(menu);
+
+        const taskProgress = document.createElement('div');
+        taskProgress.className = 'task-progress';
+        taskProgress.dataset.role = 'task-progress';
+        taskProgress.dataset.open = '0';
+        taskProgress.dataset.indeterminate = '1';
+
+        const taskBody = document.createElement('div');
+        taskBody.className = 'task-progress__body';
+
+        const taskLabel = document.createElement('div');
+        taskLabel.className = 'task-progress__label';
+        taskLabel.dataset.field = 'task-progress-label';
+        taskLabel.textContent = t('btnCopyAsPng');
+
+        const taskTrack = document.createElement('div');
+        taskTrack.className = 'task-progress__track';
+        taskTrack.setAttribute('aria-hidden', 'true');
+
+        const taskFill = document.createElement('div');
+        taskFill.className = 'task-progress__fill';
+        taskFill.dataset.field = 'task-progress-fill';
+        taskTrack.appendChild(taskFill);
+        taskBody.append(taskLabel, taskTrack);
+
+        const cancel = document.createElement('button');
+        cancel.type = 'button';
+        cancel.className = 'task-progress__cancel';
+        cancel.dataset.action = 'cancel-task';
+        cancel.setAttribute('aria-label', t('btnCancel'));
+        cancel.appendChild(createIcon(xIcon));
+        cancel.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            this.activeTaskAbort?.abort();
+            this.updateTaskProgress({ label: this.getTaskCancelledLabel(), value: 0, indeterminate: false });
+        });
+
+        taskProgress.append(taskBody, cancel);
+        bar.appendChild(taskProgress);
 
         wrap.appendChild(bar);
         this.shadow.appendChild(wrap);
@@ -427,23 +486,30 @@ export class MessageToolbar {
 
     private async handleHoverActionClick(action: MessageToolbarAction, button: HTMLButtonElement): Promise<void> {
         if (!action.hoverAction) return;
+        const abort = new AbortController();
+        this.activeTaskAbort = abort;
+        this.openTaskProgress(button, { label: action.hoverAction.label, value: 0, indeterminate: false });
         try {
             button.disabled = true;
-            this.setStatus('info', 'Working…');
-            const res = await action.hoverAction.onClick();
-            if (!res) {
-                this.setStatus('idle', '');
+            const res = await action.hoverAction.onClick({
+                signal: abort.signal,
+                onProgress: (event) => this.updateTaskProgress(event),
+            });
+            if (abort.signal.aborted) {
+                this.finishTaskProgress(this.getTaskCancelledLabel());
+            } else if (!res) {
+                this.closeTaskProgress();
             } else if (res.ok) {
-                this.setStatus('success', res.message || 'Done');
+                this.finishTaskProgress(res.message || 'Done');
                 button.setAttribute('data-flash', '1');
                 window.setTimeout(() => button.removeAttribute('data-flash'), 650);
             } else {
-                this.setStatus('error', res.message || 'Failed');
+                this.finishTaskProgress(res.message || 'Failed');
             }
         } catch {
-            this.setStatus('error', 'Failed');
+            this.finishTaskProgress(abort.signal.aborted ? this.getTaskCancelledLabel() : 'Failed');
         } finally {
-            window.setTimeout(() => this.setStatus('idle', ''), 1200);
+            if (this.activeTaskAbort === abort) this.activeTaskAbort = null;
             if (this.pending && action.disabledWhenPending) {
                 button.disabled = true;
             } else {
@@ -451,6 +517,64 @@ export class MessageToolbar {
             }
             this.closeHoverAction();
         }
+    }
+
+    private openTaskProgress(anchor: HTMLElement, initial: ToolbarTaskProgressEvent): void {
+        this.clearToolbarFeedback();
+        this.closeHoverAction();
+        if (this.taskProgressTimer !== null) {
+            window.clearTimeout(this.taskProgressTimer);
+            this.taskProgressTimer = null;
+        }
+        const progress = this.shadow.querySelector<HTMLElement>('[data-role="task-progress"]');
+        if (!progress) return;
+        progress.dataset.open = '1';
+        progress.dataset.anchorAction = anchor.dataset.action || '';
+        progress.dataset.indeterminate = '0';
+        const fill = progress.querySelector<HTMLElement>('[data-field="task-progress-fill"]');
+        if (fill) fill.style.width = '0%';
+        this.updateTaskProgress(initial);
+    }
+
+    private updateTaskProgress(event: ToolbarTaskProgressEvent): void {
+        const progress = this.shadow.querySelector<HTMLElement>('[data-role="task-progress"]');
+        if (!progress || progress.dataset.open !== '1') return;
+        const label = progress.querySelector<HTMLElement>('[data-field="task-progress-label"]');
+        const fill = progress.querySelector<HTMLElement>('[data-field="task-progress-fill"]');
+        if (event.label && label) label.textContent = event.label;
+
+        const hasRatio = Number.isFinite(event.completed) && Number.isFinite(event.total) && (event.total ?? 0) > 0;
+        const explicitValue = typeof event.value === 'number' && Number.isFinite(event.value) ? event.value : null;
+        const value = explicitValue ?? (hasRatio ? Math.round(((event.completed ?? 0) / Math.max(1, event.total ?? 1)) * 100) : null);
+        const indeterminate = event.indeterminate ?? value === null;
+        progress.dataset.indeterminate = indeterminate ? '1' : '0';
+        if (fill && value !== null) {
+            fill.style.width = `${Math.max(0, Math.min(100, value))}%`;
+        } else if (fill && indeterminate) {
+            fill.style.width = '38%';
+        }
+    }
+
+    private finishTaskProgress(label: string): void {
+        this.updateTaskProgress({ label, value: 100, indeterminate: false });
+        if (this.taskProgressTimer !== null) window.clearTimeout(this.taskProgressTimer);
+        this.taskProgressTimer = window.setTimeout(() => this.closeTaskProgress(), 1200);
+    }
+
+    private closeTaskProgress(): void {
+        if (this.taskProgressTimer !== null) {
+            window.clearTimeout(this.taskProgressTimer);
+            this.taskProgressTimer = null;
+        }
+        const progress = this.shadow.querySelector<HTMLElement>('[data-role="task-progress"]');
+        if (!progress) return;
+        progress.dataset.open = '0';
+        progress.dataset.indeterminate = '0';
+    }
+
+    private getTaskCancelledLabel(): string {
+        const translated = t('copyPngCancelled');
+        return translated && translated !== 'copyPngCancelled' ? translated : TASK_CANCELLED_LABEL;
     }
 
     private attachHoverFeedback(button: HTMLButtonElement, label: string, placement: 'top' | 'bottom'): void {
@@ -680,6 +804,91 @@ export class MessageToolbar {
 }
 .status[data-kind="success"] { border-color: var(--aimd-state-success-border); }
 .status[data-kind="error"] { border-color: var(--aimd-state-error-border); }
+
+.task-progress {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + var(--aimd-space-2));
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 100%;
+  display: none;
+  align-items: center;
+  gap: var(--aimd-space-2);
+  padding: var(--aimd-space-2);
+  border-radius: var(--aimd-radius-lg);
+  border: 1px solid color-mix(in srgb, var(--aimd-border-strong) 72%, transparent);
+  background: color-mix(in srgb, var(--aimd-bg-surface) 99%, var(--aimd-bg-primary));
+  color: var(--aimd-text-primary);
+  box-shadow: var(--aimd-shadow-lg);
+  z-index: var(--aimd-z-tooltip);
+}
+.task-progress[data-open="1"] {
+  display: flex;
+}
+.task-progress__body {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: grid;
+  gap: var(--aimd-space-1);
+}
+.task-progress__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--aimd-text-secondary);
+  font-size: var(--aimd-text-xs);
+  line-height: 1.2;
+}
+.task-progress__track {
+  position: relative;
+  height: var(--aimd-space-1);
+  overflow: hidden;
+  border-radius: var(--aimd-radius-full);
+  background: color-mix(in srgb, var(--aimd-border-default) 70%, transparent);
+}
+.task-progress__fill {
+  height: 100%;
+  width: 0%;
+  border-radius: inherit;
+  background: var(--aimd-interactive-primary);
+  transition: width var(--aimd-duration-fast) var(--aimd-ease-in-out);
+}
+.task-progress[data-indeterminate="1"] .task-progress__fill {
+  animation: taskProgressIndeterminate 1.1s var(--aimd-ease-in-out) infinite;
+}
+.task-progress__cancel {
+  all: unset;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  width: var(--aimd-size-control-icon-toolbar);
+  height: var(--aimd-size-control-icon-toolbar);
+  border-radius: var(--aimd-radius-lg);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  color: var(--aimd-button-icon-text);
+}
+.task-progress__cancel:hover {
+  background: var(--aimd-toolbar-hover);
+  color: var(--aimd-button-icon-text-hover);
+}
+.task-progress__cancel:focus-visible {
+  outline: 2px solid var(--aimd-focus-ring);
+  outline-offset: 2px;
+}
+.task-progress__cancel .aimd-icon,
+.task-progress__cancel .aimd-icon svg {
+  width: var(--aimd-size-control-glyph-panel);
+  height: var(--aimd-size-control-glyph-panel);
+  display: block;
+}
+
+@keyframes taskProgressIndeterminate {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(260%); }
+}
 
 .menu {
   position: absolute;

--- a/src/ui/content/controllers/MessageToolbarOrchestrator.ts
+++ b/src/ui/content/controllers/MessageToolbarOrchestrator.ts
@@ -23,11 +23,12 @@ import {
     nowMs,
     type CopyPngDebugEvent,
 } from '../../../services/copy/copy-png-debug';
+import type { RenderProgressEvent } from '../../../drivers/content/export/renderControl';
 import { collectConversationTurnRefs, type ConversationTurnRef } from '../../../drivers/content/conversation/collectConversationTurnRefs';
 import { buildReaderItemFromTurn, stripHash as stripReaderUrl } from '../../../services/reader/collectReaderItems';
 import { collectReaderContent, readerItemsToChatTurns } from '../../../services/reader/readerContentSource';
 import { resolveContent } from '../../../services/reader/types';
-import { MessageToolbar, type MessageToolbarAction } from '../MessageToolbar';
+import { MessageToolbar, type MessageToolbarAction, type ToolbarActionContext } from '../MessageToolbar';
 import type { BookmarksPanelController } from '../bookmarks/BookmarksPanelController';
 import type { ReaderPanel, ReaderPanelAction } from '../reader/ReaderPanel';
 import type { SendController } from '../sending/SendController';
@@ -565,7 +566,7 @@ export class MessageToolbarOrchestrator {
                 id: 'copy_png',
                 label: t('btnCopyAsPng'),
                 icon: imageIcon,
-                onClick: async () => {
+                onClick: async (ctx?: ToolbarActionContext) => {
                     const debugEnabled = isCopyPngDebugEnabled();
                     const copyStartedAt = nowMs();
                     const debugEvents: CopyPngDebugEvent[] = [];
@@ -615,9 +616,14 @@ export class MessageToolbarOrchestrator {
                         },
                         png: { width: this.resolvedPngWidth, pixelRatio: this.resolvedPngPixelRatio },
                         onDebug: emitDebug,
+                        signal: ctx?.signal,
+                        onProgress: (event) => {
+                            ctx?.onProgress(this.formatCopyPngProgress(event));
+                        },
                     });
                     if (!result.ok) {
                         finishDebug(result.error.code);
+                        if (result.cancelled) return { ok: false, message: this.getCopyPngCancelledLabel() };
                         return { ok: false, message: result.error.message };
                     }
                     if (result.noop) {
@@ -1114,6 +1120,58 @@ export class MessageToolbarOrchestrator {
         } catch {
             return false;
         }
+    }
+
+    private formatCopyPngProgress(event: RenderProgressEvent): {
+        label: string;
+        completed?: number;
+        total?: number;
+        value?: number;
+        indeterminate?: boolean;
+    } {
+        const completed = event.completed;
+        const total = event.total;
+        const hasRatio = Number.isFinite(completed) && Number.isFinite(total) && (total ?? 0) > 0;
+        const base = hasRatio ? `${completed}/${total}` : '0/1';
+        switch (event.phase) {
+            case 'preparing':
+                return { label: t('pngExportPreparing', base), value: 0, indeterminate: false };
+            case 'loading_assets':
+                return { label: t('pngExportPreparing', base), value: 0, indeterminate: false };
+            case 'rendering':
+                return {
+                    label: t('pngExportRendering', hasRatio ? base : '0/1'),
+                    completed,
+                    total,
+                    value: hasRatio ? undefined : 0,
+                    indeterminate: false,
+                };
+            case 'rendering_chunk':
+                return {
+                    label: t('pngExportRendering', base),
+                    completed,
+                    total,
+                    indeterminate: !hasRatio,
+                };
+            case 'stitching':
+                return {
+                    label: t('pngExportRendering', base),
+                    completed,
+                    total,
+                    indeterminate: !hasRatio,
+                };
+            case 'encoding':
+                return { label: t('pngExportDownloading'), value: 95, indeterminate: false };
+            case 'done':
+                return { label: t('pngExportDone', '1/1'), completed: 1, total: 1 };
+            default:
+                return { label: t('btnCopyAsPng'), indeterminate: true };
+        }
+    }
+
+    private getCopyPngCancelledLabel(): string {
+        const translated = t('copyPngCancelled');
+        return translated && translated !== 'copyPngCancelled' ? translated : 'Cancelled';
     }
 
     private handleObservedMutations(mutations: ArrayLike<MutationRecord | { addedNodes?: ArrayLike<Node>; removedNodes?: ArrayLike<Node> }>): void {

--- a/src/ui/content/export/SaveMessagesDialog.ts
+++ b/src/ui/content/export/SaveMessagesDialog.ts
@@ -10,7 +10,7 @@ import type { ChatGPTConversationEngine } from '../../../drivers/content/chatgpt
 import { buildConversationMetadata } from '../../../drivers/content/conversation/metadata';
 import { getTokenCss } from '../../../style/tokens';
 import { subscribeLocaleChange, t } from '../components/i18n';
-import type { TranslateFn, SaveFormat } from '../../../services/export/saveMessagesTypes';
+import type { ExportProgressEvent, TranslateFn, SaveFormat } from '../../../services/export/saveMessagesTypes';
 import {
     exportTurnsMarkdown,
     exportTurnsPdf,
@@ -35,6 +35,8 @@ type State = {
     turnsCount: number;
     progressText: string;
     progressValue: number | null;
+    currentProgressText: string;
+    currentProgressValue: number | null;
 };
 
 export class SaveMessagesDialog {
@@ -60,10 +62,13 @@ export class SaveMessagesDialog {
         turnsCount: 0,
         progressText: '',
         progressValue: null,
+        currentProgressText: '',
+        currentProgressValue: null,
     };
     private closing = false;
     private motionNeedsOpen = false;
     private readonly focusLifecycle = new SurfaceFocusLifecycle();
+    private pngExportAbort: AbortController | null = null;
 
     isOpen(): boolean {
         return Boolean(this.overlaySession);
@@ -99,6 +104,8 @@ export class SaveMessagesDialog {
         this.state.saving = false;
         this.state.progressText = '';
         this.state.progressValue = null;
+        this.state.currentProgressText = '';
+        this.state.currentProgressValue = null;
         if (this.overlaySession && this.closing) {
             cancelSurfaceMotionClose({
                 shell: this.overlaySession.surfaceRoot.querySelector<HTMLElement>('.panel-window'),
@@ -114,6 +121,7 @@ export class SaveMessagesDialog {
 
     close(): void {
         if (this.closing) return;
+        this.pngExportAbort?.abort();
         const panel = this.overlaySession?.surfaceRoot.querySelector<HTMLElement>('.panel-window');
         const backdrop = this.overlaySession?.backdropRoot.querySelector<HTMLElement>('.panel-stage__overlay');
         if (this.overlaySession && panel) {
@@ -272,7 +280,11 @@ export class SaveMessagesDialog {
         this.state.saving = true;
         this.state.progressText = '';
         this.state.progressValue = null;
+        this.state.currentProgressText = '';
+        this.state.currentProgressValue = null;
         this.render();
+        const pngAbort = format === 'png' ? new AbortController() : null;
+        this.pngExportAbort = pngAbort;
 
         try {
             const res =
@@ -285,9 +297,9 @@ export class SaveMessagesDialog {
                     ? await exportTurnsPng(turns, selectedIndices, metadata, {
                           t: this.exportT,
                           png: { width: this.resolvedPngWidth, pixelRatio: this.resolvedPngPixelRatio },
+                          signal: pngAbort?.signal,
                           onProgress: (event) => {
-                              this.state.progressValue = event.total > 0 ? Math.round((event.completed / event.total) * 100) : null;
-                              this.state.progressText = this.getPngProgressLabel(event.phase, event.completed, event.total, event.filename);
+                              this.applyPngProgress(event);
                               if (this.overlaySession && !this.closing) this.render();
                           },
                       })
@@ -297,6 +309,7 @@ export class SaveMessagesDialog {
             if (format !== 'pdf') this.close();
         } finally {
             this.state.saving = false;
+            if (this.pngExportAbort === pngAbort) this.pngExportAbort = null;
             if (this.overlaySession && !this.closing) this.render();
         }
     }
@@ -313,8 +326,9 @@ export class SaveMessagesDialog {
         const deselectAllLabel = this.getLabel('deselectAll', 'Deselect all');
         const saveLabel = this.state.saving ? this.getLabel('saving', 'Saving') : this.getLabel('btnSave', 'Save');
         const countLabel = this.getSelectedCountLabel();
-        const showProgress = this.state.format === 'png' && this.state.saving && Boolean(this.state.progressText);
-        const progressValue = this.state.progressValue ?? 0;
+        const showProgress = this.state.format === 'png' && this.state.saving && (Boolean(this.state.progressText) || Boolean(this.state.currentProgressText));
+        const totalProgressValue = this.state.progressValue ?? 0;
+        const currentProgressValue = this.state.currentProgressValue ?? 0;
 
         return `
 <div class="panel-window panel-window--dialog panel-window--save" role="dialog" aria-modal="true" aria-label="${escapeHtml(title)}">
@@ -342,9 +356,18 @@ export class SaveMessagesDialog {
     </div>
     ${showProgress ? `
     <div class="progress-panel">
-      <div class="progress-label">${escapeHtml(this.state.progressText)}</div>
-      <div class="progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${progressValue}">
-        <div class="progress-fill" style="width: ${progressValue}%"></div>
+      ${this.state.currentProgressText ? `
+      <div class="progress-row">
+        <div class="progress-label">${escapeHtml(this.state.currentProgressText)}</div>
+        <div class="progress-track" role="progressbar" aria-label="${escapeHtml(this.getLabel('pngExportCurrentProgressLabel', 'Current message'))}" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${currentProgressValue}">
+          <div class="progress-fill" style="width: ${currentProgressValue}%"></div>
+        </div>
+      </div>` : ''}
+      <div class="progress-row">
+        <div class="progress-label">${escapeHtml(this.state.progressText)}</div>
+        <div class="progress-track" role="progressbar" aria-label="${escapeHtml(this.getLabel('pngExportTotalProgressLabel', 'Total export'))}" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${totalProgressValue}">
+          <div class="progress-fill" style="width: ${totalProgressValue}%"></div>
+        </div>
       </div>
     </div>` : ''}
   </div>
@@ -381,6 +404,70 @@ ${getSaveMessagesDialogCss(this.state.theme)}
         const translated = t('selectedCountMessages', [count, total]);
         if (!translated || translated === 'selectedCountMessages') return `${count}/${total} selected`;
         return translated;
+    }
+
+    private applyPngProgress(event: ExportProgressEvent): void {
+        this.state.progressValue = event.total > 0 ? Math.round((event.completed / event.total) * 100) : null;
+        this.state.progressText = this.getPngProgressLabel(event.phase, event.completed, event.total, event.filename);
+
+        if (event.current) {
+            this.state.currentProgressValue = this.resolveCurrentPngProgressValue(event.current.completed, event.current.total, event.current.phase);
+            this.state.currentProgressText = this.getCurrentPngProgressLabel(
+                event.current.phase,
+                event.current.completed,
+                event.current.total,
+                event.filename,
+            );
+            return;
+        }
+
+        if (event.phase === 'rendering') {
+            this.state.currentProgressValue = 0;
+            this.state.currentProgressText = event.filename
+                ? this.getLabel('pngExportCurrentPreparingWithFilename', `Current message 0/1: ${event.filename}`, ['0/1', event.filename])
+                : this.getLabel('pngExportCurrentPreparing', 'Current message 0/1', ['0/1']);
+            return;
+        }
+
+        this.state.currentProgressValue = null;
+        this.state.currentProgressText = '';
+    }
+
+    private resolveCurrentPngProgressValue(completed?: number, total?: number, phase?: string): number | null {
+        if (Number.isFinite(completed) && Number.isFinite(total) && (total ?? 0) > 0) {
+            return Math.round(((completed ?? 0) / Math.max(1, total ?? 1)) * 100);
+        }
+        if (phase === 'encoding') return 95;
+        if (phase === 'done') return 100;
+        return 0;
+    }
+
+    private getCurrentPngProgressLabel(phase: string, completed?: number, total?: number, filename?: string): string {
+        const hasRatio = Number.isFinite(completed) && Number.isFinite(total) && (total ?? 0) > 0;
+        const base = hasRatio ? `${completed}/${total}` : '0/1';
+        switch (phase) {
+            case 'preparing':
+            case 'loading_assets':
+                return filename
+                    ? this.getLabel('pngExportCurrentPreparingWithFilename', `Current message ${base}: ${filename}`, [base, filename])
+                    : this.getLabel('pngExportCurrentPreparing', `Current message ${base}`, [base]);
+            case 'rendering':
+            case 'rendering_chunk':
+            case 'stitching':
+                return filename
+                    ? this.getLabel('pngExportCurrentRenderingWithFilename', `Current message ${base}: ${filename}`, [base, filename])
+                    : this.getLabel('pngExportCurrentRendering', `Current message ${base}`, [base]);
+            case 'encoding':
+                return filename
+                    ? this.getLabel('pngExportCurrentEncodingWithFilename', `Encoding current message: ${filename}`, [filename])
+                    : this.getLabel('pngExportCurrentEncoding', 'Encoding current message');
+            case 'done':
+                return filename
+                    ? this.getLabel('pngExportCurrentDoneWithFilename', `Current message ready: ${filename}`, [filename])
+                    : this.getLabel('pngExportCurrentDone', 'Current message ready');
+            default:
+                return base;
+        }
     }
 
     private getPngProgressLabel(phase: string, completed: number, total: number, filename?: string): string {

--- a/src/ui/content/export/saveMessagesDialogCss.ts
+++ b/src/ui/content/export/saveMessagesDialogCss.ts
@@ -151,8 +151,13 @@ ${getPanelChromeCss()}
 
 .progress-panel {
   display: grid;
-  gap: var(--aimd-space-2);
+  gap: var(--aimd-space-3);
   margin-top: var(--aimd-space-4);
+}
+
+.progress-row {
+  display: grid;
+  gap: var(--aimd-space-2);
 }
 
 .progress-label {

--- a/tests/unit/drivers/content/export/renderPng.test.ts
+++ b/tests/unit/drivers/content/export/renderPng.test.ts
@@ -262,6 +262,45 @@ describe('renderPngBlob', () => {
         scrollHeight.mockRestore();
     });
 
+    it('splits low-height chunks by DOM complexity without changing the height trigger', async () => {
+        const scrollHeight = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(2500);
+        const offsetHeight = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(50);
+        const onMetrics = vi.fn();
+        const denseSpans = Array.from({ length: 650 }, (_, index) => `<span class="token">token-${index}</span>`).join('');
+        const html = `
+<div class="aimd-png-export-card">
+  <div class="reader-markdown markdown-body">
+    <p>plain-start</p>
+    <pre><code>${denseSpans}</code></pre>
+    <p>plain-end</p>
+  </div>
+</div>`;
+
+        await renderPngBlob({
+            filename: 'complexity-budget.png',
+            html,
+            width: 800,
+            pixelRatio: 1,
+            backgroundColor: '#ffffff',
+            onMetrics,
+        });
+
+        expect(toCanvas).toHaveBeenCalledTimes(3);
+        const renderedHtml = vi.mocked(toCanvas).mock.calls.map((call) => (call[0] as HTMLElement).textContent || '');
+        expect(renderedHtml[0]).toContain('plain-start');
+        expect(renderedHtml[0]).not.toContain('token-0');
+        expect(renderedHtml[1]).toContain('token-0');
+        expect(renderedHtml[1]).toContain('token-649');
+        expect(renderedHtml[1]).not.toContain('plain-end');
+        expect(renderedHtml[2]).toContain('plain-end');
+        expect(onMetrics).toHaveBeenCalledWith(expect.objectContaining({
+            strategy: 'chunked',
+            chunkCount: 3,
+        }));
+        scrollHeight.mockRestore();
+        offsetHeight.mockRestore();
+    });
+
     it('throws a useful error when html-to-image canvas rendering fails', async () => {
         vi.mocked(toCanvas).mockRejectedValueOnce(new Error('render-fail'));
 
@@ -272,5 +311,19 @@ describe('renderPngBlob', () => {
             pixelRatio: 2,
             backgroundColor: '#ffffff',
         })).rejects.toThrow('PNG export failed');
+    });
+
+    it('preserves abort errors instead of wrapping them as PNG export failures', async () => {
+        const abort = new AbortController();
+        abort.abort();
+
+        await expect(renderPngBlob({
+            filename: 'cancelled.png',
+            html: '<div>cancelled</div>',
+            width: 800,
+            pixelRatio: 2,
+            backgroundColor: '#ffffff',
+            signal: abort.signal,
+        })).rejects.toMatchObject({ name: 'AbortError' });
     });
 });

--- a/tests/unit/services/copy/copy-turn-png.test.ts
+++ b/tests/unit/services/copy/copy-turn-png.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../../../src/drivers/content/export/renderPng', () => ({
     renderPngBlob: vi.fn(async (plan: any) => {
+        plan.onProgress?.({ phase: 'rendering_chunk', completed: 1, total: 3 });
         plan.onMetrics?.({
             width: 1200,
             height: 12000,
@@ -130,5 +131,28 @@ describe('copyTurnsPng', () => {
         });
         expect(JSON.stringify(onDebug.mock.calls)).not.toContain('u2');
         expect(JSON.stringify(onDebug.mock.calls)).not.toContain('a2');
+    });
+
+    it('passes renderer progress and abort signal through while avoiding clipboard writes after cancellation', async () => {
+        const abort = new AbortController();
+        const onProgress = vi.fn();
+        const blob = new Blob(['png'], { type: 'image/png' });
+        vi.mocked(renderPngBlob).mockImplementationOnce(async (plan: any) => {
+            expect(plan.signal).toBe(abort.signal);
+            plan.onProgress?.({ phase: 'rendering_chunk', completed: 1, total: 2 });
+            abort.abort();
+            return blob;
+        });
+
+        const result = await copyTurnsPng(turns, [0], metadata, { t, signal: abort.signal, onProgress });
+
+        expect(result).toEqual({
+            ok: false,
+            cancelled: true,
+            error: { code: 'CANCELLED', message: 'btnCancel' },
+        });
+        expect(onProgress).toHaveBeenCalledWith({ phase: 'rendering_chunk', completed: 1, total: 2 });
+        expect(copyImageBlobToClipboard).not.toHaveBeenCalled();
+        expect(downloadBlob).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/services/export/saveMessagesFacade.test.ts
+++ b/tests/unit/services/export/saveMessagesFacade.test.ts
@@ -7,7 +7,10 @@ vi.mock('../../../../src/drivers/content/export/printPdf', () => ({
     printPdf: vi.fn(),
 }));
 vi.mock('../../../../src/drivers/content/export/renderPng', () => ({
-    renderPngBlob: vi.fn(async (plan: any) => new Blob([plan.filename], { type: 'image/png' })),
+    renderPngBlob: vi.fn(async (plan: any) => {
+        plan.onProgress?.({ phase: 'rendering_chunk', completed: 1, total: 3 });
+        return new Blob([plan.filename], { type: 'image/png' });
+    }),
 }));
 vi.mock('../../../../src/drivers/content/export/downloadBlob', () => ({
     downloadBlob: vi.fn(),
@@ -18,6 +21,7 @@ vi.mock('../../../../src/drivers/content/export/zipBlobs', () => ({
 
 import { downloadText } from '../../../../src/drivers/content/export/downloadFile';
 import { downloadBlob } from '../../../../src/drivers/content/export/downloadBlob';
+import { renderPngBlob } from '../../../../src/drivers/content/export/renderPng';
 import { zipBlobs } from '../../../../src/drivers/content/export/zipBlobs';
 import { exportTurnsMarkdown, exportTurnsPng } from '../../../../src/services/export/saveMessagesFacade';
 import type { ChatTurn, ConversationMetadata } from '../../../../src/services/export/saveMessagesTypes';
@@ -114,6 +118,8 @@ describe('exportTurnsPng', () => {
         expect(progress).toEqual([
             'preparing:0/2',
             'rendering:0/2',
+            'rendering:0/2',
+            'rendering:1/2',
             'rendering:1/2',
             'rendering:1/2',
             'rendering:2/2',
@@ -121,5 +127,45 @@ describe('exportTurnsPng', () => {
             'downloading:2/2',
             'done:2/2',
         ]);
+    });
+
+    it('reports current message PNG render progress inside the total export progress event', async () => {
+        const progress: any[] = [];
+
+        const res = await exportTurnsPng(turns, [0], metadata, {
+            t,
+            onProgress: (event: any) => progress.push(event),
+        });
+
+        expect(res.ok).toBe(true);
+        expect(progress).toContainEqual(expect.objectContaining({
+            phase: 'rendering',
+            completed: 0,
+            total: 1,
+            filename: 'PNG_Export-message-001.png',
+            current: { phase: 'rendering_chunk', completed: 1, total: 3 },
+        }));
+    });
+
+    it('cancels PNG export before downloading when the abort signal fires', async () => {
+        vi.mocked(downloadBlob).mockClear();
+        const abort = new AbortController();
+        vi.mocked(renderPngBlob).mockImplementationOnce(async (plan: any) => {
+            plan.onProgress?.({ phase: 'rendering_chunk', completed: 1, total: 2 });
+            abort.abort();
+            return new Blob([plan.filename], { type: 'image/png' });
+        });
+
+        const res = await exportTurnsPng(turns, [0], metadata, {
+            t,
+            signal: abort.signal,
+        });
+
+        expect(res).toEqual({
+            ok: false,
+            cancelled: true,
+            error: { code: 'CANCELLED', message: 'pngExportCancelled' },
+        });
+        expect(downloadBlob).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/ui/content/MessageToolbar.test.ts
+++ b/tests/unit/ui/content/MessageToolbar.test.ts
@@ -323,4 +323,122 @@ describe('MessageToolbar', () => {
         toolbar.getElement().remove();
         vi.useRealTimers();
     });
+
+    it('shows a toolbar-width cancellable progress panel while Copy PNG runs', async () => {
+        vi.useFakeTimers();
+        let resolveCopy: ((value: { ok: true; message: string }) => void) | null = null;
+        let receivedSignal: AbortSignal | null = null;
+        const onCopyPng = vi.fn((ctx: any) => {
+            receivedSignal = ctx.signal;
+            ctx.onProgress({ label: 'Rendering 1/3', completed: 1, total: 3 });
+            return new Promise<{ ok: true; message: string }>((resolve) => {
+                resolveCopy = resolve;
+            });
+        });
+        const toolbar = new MessageToolbar('light', [
+            {
+                id: 'copy_markdown',
+                label: 'Copy Markdown',
+                tooltip: 'Copy Markdown',
+                icon: '<svg viewBox="0 0 16 16"></svg>',
+                onClick: vi.fn(async () => ({ ok: true as const, message: 'Copied!' })),
+                hoverAction: {
+                    id: 'copy_png',
+                    label: 'Copy as PNG',
+                    icon: '<svg viewBox="0 0 16 16"></svg>',
+                    onClick: onCopyPng,
+                },
+            },
+        ], { showStats: false });
+
+        document.body.appendChild(toolbar.getElement());
+        const trigger = toolbar.getElement().shadowRoot!.querySelector<HTMLButtonElement>('[data-action="copy_markdown"]')!;
+        trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+        vi.advanceTimersByTime(100);
+
+        const secondaryButton = document
+            .querySelector<HTMLElement>('.aimd-toolbar-hover-action-host')!
+            .shadowRoot!
+            .querySelector<HTMLButtonElement>('[data-role="toolbar-hover-action"]')!;
+        secondaryButton.click();
+        await Promise.resolve();
+
+        const shadow = toolbar.getElement().shadowRoot!;
+        const progress = shadow.querySelector<HTMLElement>('[data-role="task-progress"]')!;
+        const label = shadow.querySelector<HTMLElement>('[data-field="task-progress-label"]')!;
+        const fill = shadow.querySelector<HTMLElement>('[data-field="task-progress-fill"]')!;
+        const cancel = shadow.querySelector<HTMLButtonElement>('[data-action="cancel-task"]')!;
+        const css = shadow.querySelector<HTMLStyleElement>('style[data-aimd-style-id="aimd-toolbar-base"]')?.textContent ?? '';
+
+        expect(progress.dataset.open).toBe('1');
+        expect(label.textContent).toBe('Rendering 1/3');
+        expect(fill.style.width).toBe('33%');
+        expect(css).toContain('.task-progress {');
+        expect(css).toContain('width: 100%;');
+        expect(cancel.getAttribute('aria-label')).toBe('btnCancel');
+
+        cancel.click();
+        expect(receivedSignal?.aborted).toBe(true);
+
+        resolveCopy?.({ ok: true, message: 'PNG copied!' });
+        await Promise.resolve();
+        expect(label.textContent).toBe('Cancelled');
+
+        toolbar.dispose();
+        toolbar.getElement().remove();
+        vi.useRealTimers();
+    });
+
+    it('keeps determinate progress at zero until completed work is reported', async () => {
+        vi.useFakeTimers();
+        let resolveCopy: ((value: { ok: true; message: string }) => void) | null = null;
+        const onCopyPng = vi.fn((ctx: any) => {
+            ctx.onProgress({ label: 'Preparing', value: 0, indeterminate: false });
+            ctx.onProgress({ label: 'Rendering 1/3', completed: 1, total: 3, indeterminate: false });
+            return new Promise<{ ok: true; message: string }>((resolve) => {
+                resolveCopy = resolve;
+            });
+        });
+        const toolbar = new MessageToolbar('light', [
+            {
+                id: 'copy_markdown',
+                label: 'Copy Markdown',
+                tooltip: 'Copy Markdown',
+                icon: '<svg viewBox="0 0 16 16"></svg>',
+                onClick: vi.fn(async () => ({ ok: true as const, message: 'Copied!' })),
+                hoverAction: {
+                    id: 'copy_png',
+                    label: 'Copy as PNG',
+                    icon: '<svg viewBox="0 0 16 16"></svg>',
+                    onClick: onCopyPng,
+                },
+            },
+        ], { showStats: false });
+
+        document.body.appendChild(toolbar.getElement());
+        const trigger = toolbar.getElement().shadowRoot!.querySelector<HTMLButtonElement>('[data-action="copy_markdown"]')!;
+        trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+        vi.advanceTimersByTime(100);
+
+        document
+            .querySelector<HTMLElement>('.aimd-toolbar-hover-action-host')!
+            .shadowRoot!
+            .querySelector<HTMLButtonElement>('[data-role="toolbar-hover-action"]')!
+            .click();
+        await Promise.resolve();
+
+        const shadow = toolbar.getElement().shadowRoot!;
+        const progress = shadow.querySelector<HTMLElement>('[data-role="task-progress"]')!;
+        const fill = shadow.querySelector<HTMLElement>('[data-field="task-progress-fill"]')!;
+
+        expect(progress.dataset.indeterminate).toBe('0');
+        expect(fill.style.width).toBe('33%');
+
+        resolveCopy?.({ ok: true, message: 'PNG copied!' });
+        await Promise.resolve();
+
+        toolbar.dispose();
+        toolbar.getElement().remove();
+        vi.useRealTimers();
+    });
 });

--- a/tests/unit/ui/content/messageToolbarOrchestrator.copy-png.test.ts
+++ b/tests/unit/ui/content/messageToolbarOrchestrator.copy-png.test.ts
@@ -71,16 +71,88 @@ describe('MessageToolbarOrchestrator Copy PNG', () => {
         const actions = orchestrator.getActionsForMessage(assistant, () => null);
         const copyAction = actions.find((action: any) => action.id === 'copy_markdown');
 
-        await copyAction.hoverAction.onClick();
+        const abort = new AbortController();
+        const onProgress = vi.fn();
+        await copyAction.hoverAction.onClick({ signal: abort.signal, onProgress });
 
         expect(copyTurnsPng).toHaveBeenCalledWith(
             [{ user: 'Prompt', assistant: 'Answer', index: 0 }],
             [0],
             expect.objectContaining({ title: 'PNG Width Test', count: 1 }),
-            expect.objectContaining({ png: { width: 640, pixelRatio: 2.5 } }),
+            expect.objectContaining({
+                png: { width: 640, pixelRatio: 2.5 },
+                signal: abort.signal,
+                onProgress: expect.any(Function),
+            }),
         );
         expect(collectReaderContent).toHaveBeenCalledWith(expect.any(TestAdapter), assistant, expect.objectContaining({
             pageUrl: window.location.href,
         }));
+    });
+
+    it('maps renderer progress into toolbar progress labels', async () => {
+        document.body.innerHTML = `
+          <title>PNG Progress Test</title>
+          <div class="assistant-message" data-message-id="m1" data-aimd-msg-position="7">
+            <div class="content">Answer</div>
+            <div class="official-toolbar"><button>copy</button></div>
+          </div>
+        `;
+
+        vi.mocked(copyTurnsPng).mockImplementationOnce(async (_turns, _selected, _metadata, options: any) => {
+            options.onProgress({ phase: 'rendering_chunk', completed: 2, total: 4 });
+            return { ok: true, noop: false };
+        });
+
+        const orchestrator = new MessageToolbarOrchestrator(new TestAdapter(), {
+            readerPanel: { show: vi.fn(), setTheme: vi.fn() } as any,
+        }) as any;
+        orchestrator.getUserPromptForElement = vi.fn(() => 'Prompt');
+
+        const assistant = document.querySelector('.assistant-message') as HTMLElement;
+        const actions = orchestrator.getActionsForMessage(assistant, () => null);
+        const copyAction = actions.find((action: any) => action.id === 'copy_markdown');
+        const onProgress = vi.fn();
+
+        await copyAction.hoverAction.onClick({ signal: new AbortController().signal, onProgress });
+
+        expect(onProgress).toHaveBeenCalledWith(expect.objectContaining({
+            label: expect.any(String),
+            completed: 2,
+            total: 4,
+            indeterminate: false,
+        }));
+    });
+
+    it('reports cancelled Copy PNG as a short cancellation message', async () => {
+        document.body.innerHTML = `
+          <title>PNG Cancel Test</title>
+          <div class="assistant-message" data-message-id="m1" data-aimd-msg-position="7">
+            <div class="content">Answer</div>
+            <div class="official-toolbar"><button>copy</button></div>
+          </div>
+        `;
+
+        vi.mocked(copyTurnsPng).mockResolvedValueOnce({
+            ok: false,
+            cancelled: true,
+            error: {
+                code: 'CANCELLED',
+                message: 'PNG export failed for message.png (800x4000, pixelRatio 1): Operation cancelled.',
+            },
+        });
+
+        const orchestrator = new MessageToolbarOrchestrator(new TestAdapter(), {
+            readerPanel: { show: vi.fn(), setTheme: vi.fn() } as any,
+        }) as any;
+        orchestrator.getUserPromptForElement = vi.fn(() => 'Prompt');
+
+        const assistant = document.querySelector('.assistant-message') as HTMLElement;
+        const actions = orchestrator.getActionsForMessage(assistant, () => null);
+        const copyAction = actions.find((action: any) => action.id === 'copy_markdown');
+
+        const result = await copyAction.hoverAction.onClick({ signal: new AbortController().signal, onProgress: vi.fn() });
+
+        expect(result).toEqual({ ok: false, message: 'Cancelled' });
     });
 });

--- a/tests/unit/ui/export/saveMessagesDialog.test.ts
+++ b/tests/unit/ui/export/saveMessagesDialog.test.ts
@@ -154,6 +154,13 @@ describe('SaveMessagesDialog', () => {
         vi.mocked(exportTurnsPng).mockImplementationOnce(async (_turns, _indices, _metadata, options: any) => {
             expect(options.png).toEqual({ width: 800, pixelRatio: 1 });
             options.onProgress?.({ phase: 'rendering', completed: 1, total: 2, filename: 'message-001.png' });
+            options.onProgress?.({
+                phase: 'rendering',
+                completed: 1,
+                total: 2,
+                filename: 'message-001.png',
+                current: { phase: 'rendering_chunk', completed: 2, total: 5 },
+            });
             await new Promise<void>((resolve) => {
                 resolveExport = resolve;
             });
@@ -175,9 +182,53 @@ describe('SaveMessagesDialog', () => {
         shadow.querySelector<HTMLButtonElement>('[data-action="save-turns"]')!.click();
         await flushUi();
 
-        expect(shadow.querySelector('[role="progressbar"]')).toBeTruthy();
+        const progressBars = shadow.querySelectorAll('[role="progressbar"]');
+        expect(progressBars).toHaveLength(2);
+        expect(progressBars[0].getAttribute('aria-label')).toBe('Current message');
+        expect(progressBars[0].getAttribute('aria-valuenow')).toBe('40');
+        expect(progressBars[1].getAttribute('aria-label')).toBe('Total export');
+        expect(progressBars[1].getAttribute('aria-valuenow')).toBe('50');
+        expect(shadow.textContent).toContain('Current message 2/5');
         expect(shadow.textContent).toContain('1/2');
         expect(shadow.textContent).toContain('message-001.png');
+        expect(shadow.querySelector('[data-action="cancel-png-export"]')).toBeNull();
+
+        resolveExport();
+        await flushUi();
+    });
+
+    it('cancels a running PNG export when the dialog close button is clicked', async () => {
+        await setLocale('en');
+        const adapter = { getPlatformId: () => 'chatgpt' } as any;
+        let signal: AbortSignal | null = null;
+        let resolveExport!: () => void;
+        vi.mocked(exportTurnsPng).mockImplementationOnce(async (_turns, _indices, _metadata, options: any) => {
+            signal = options.signal;
+            options.onProgress?.({
+                phase: 'rendering',
+                completed: 0,
+                total: 2,
+                filename: 'message-001.png',
+                current: { phase: 'rendering_chunk', completed: 1, total: 4 },
+            });
+            await new Promise<void>((resolve) => {
+                resolveExport = resolve;
+            });
+            return { ok: false, cancelled: true, error: { code: 'CANCELLED', message: 'copyPngCancelled' } };
+        });
+
+        const dlg = new SaveMessagesDialog();
+        await dlg.open(adapter, 'light');
+
+        const host = document.getElementById('aimd-save-messages-dialog-host')!;
+        const shadow = host.shadowRoot!;
+        shadow.querySelector<HTMLElement>('[data-action="set-format"][data-format="png"]')!.click();
+        shadow.querySelector<HTMLButtonElement>('[data-action="save-turns"]')!.click();
+        await flushUi();
+
+        shadow.querySelector<HTMLButtonElement>('[data-action="close-panel"]')!.click();
+        expect(signal?.aborted).toBe(true);
+        expect(shadow.querySelector<HTMLElement>('.panel-window--save')?.dataset.motionState).toBe('closing');
 
         resolveExport();
         await flushUi();
@@ -210,6 +261,13 @@ describe('SaveMessagesDialog', () => {
         let resolveExport!: () => void;
         vi.mocked(exportTurnsPng).mockImplementationOnce(async (_turns, _indices, _metadata, options: any) => {
             options.onProgress?.({ phase: 'rendering', completed: 1, total: 2, filename: 'message-001.png' });
+            options.onProgress?.({
+                phase: 'rendering',
+                completed: 1,
+                total: 2,
+                filename: 'message-001.png',
+                current: { phase: 'rendering_chunk', completed: 1, total: 4 },
+            });
             await new Promise<void>((resolve) => {
                 resolveExport = resolve;
             });
@@ -225,6 +283,7 @@ describe('SaveMessagesDialog', () => {
         shadow.querySelector<HTMLButtonElement>('[data-action="save-turns"]')!.click();
         await flushUi();
 
+        expect(shadow.textContent).toContain('当前消息 1/4');
         expect(shadow.textContent).toContain('正在渲染 1/2');
         expect(shadow.textContent).toContain('message-001.png');
 


### PR DESCRIPTION
# Pull Request

## Description
本 PR 改进了 PNG 复制和导出体验。PNG 渲染现在除了按高度分块外，也会按 DOM 复杂度分块，从而减少包含公式、代码块、表格或图片的复杂消息导致的长时间浏览器卡顿。Copy as PNG 现在会显示专用的进度面板，并支持取消；Save Messages 的 PNG 导出现在会同时显示当前消息进度和总导出进度。在 PNG 导出过程中关闭 Save Messages 弹窗时，也会取消正在进行的导出。

## Related Issue
Closes #6

## Type of Change
- New feature
- Performance improvement

## Testing Checklist
已在包含大量公式的消息上测试 ChatGPT 的 PNG 复制/导出。Gemini 未测试，因为本次改动针对的是 ChatGPT 消息工具栏和 Save Messages 的 PNG 导出流程。


## Screenshots
<img width="1311" height="720" alt="image" src="https://github.com/user-attachments/assets/4f81c26b-b0c9-454b-a2b1-58efbe25b85d" />
<img width="1371" height="1152" alt="image" src="https://github.com/user-attachments/assets/2ce8af9e-74e5-43c5-a692-62c44bd87fdd" />
