### PR TITLE
修复 Reader 内嵌 Markdown 局部选区被扩展成整块

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Reader: Selecting text inside code blocks, inline code, or tables now keeps copy, annotations, and sticky pins limited to the exact selected text instead of expanding to the whole Markdown block.
+
 ## [4.5.1] - 2026-06-07
 
 ### Added

--- a/src/services/reader/atomicExport.ts
+++ b/src/services/reader/atomicExport.ts
@@ -40,7 +40,8 @@ export function buildAtomicSelectionExport(params: {
         }
 
         if (node instanceof Text) {
-            if (node.parentElement?.closest('[data-aimd-unit-id]')) return '';
+            const selectedUnitElement = node.parentElement?.closest<HTMLElement>('[data-aimd-unit-id]');
+            if (selectedUnitElement && selectedUnitMap.has(selectedUnitElement)) return '';
             return collectTextSlice(node);
         }
 

--- a/src/services/reader/atomicExport.ts
+++ b/src/services/reader/atomicExport.ts
@@ -40,8 +40,7 @@ export function buildAtomicSelectionExport(params: {
         }
 
         if (node instanceof Text) {
-            const selectedUnitElement = node.parentElement?.closest<HTMLElement>('[data-aimd-unit-id]');
-            if (selectedUnitElement && selectedUnitMap.has(selectedUnitElement)) return '';
+            if (hasSelectedUnitAncestor(node, root, selectedUnitMap)) return '';
             return collectTextSlice(node);
         }
 
@@ -49,6 +48,16 @@ export function buildAtomicSelectionExport(params: {
     };
 
     return visit(root).replace(/\n{3,}/g, '\n\n').trim();
+}
+
+function hasSelectedUnitAncestor(textNode: Text, root: HTMLElement, selectedUnitMap: Map<HTMLElement, SelectedAtomicUnit>): boolean {
+    let current = textNode.parentElement;
+    while (current && root.contains(current)) {
+        if (selectedUnitMap.has(current)) return true;
+        if (current === root) return false;
+        current = current.parentElement;
+    }
+    return false;
 }
 
 function isBlockUnit(unit: SelectedAtomicUnit): boolean {

--- a/src/services/reader/atomicSelection.ts
+++ b/src/services/reader/atomicSelection.ts
@@ -35,13 +35,14 @@ function isStructuralUnitKind(kind: ReaderAtomicUnitKind | null): boolean {
 }
 
 export function resolveRenderedAtomicUnitKind(element: HTMLElement): ReaderAtomicUnitKind | null {
+    if (element.matches('code') && element.closest('pre')) return null;
     const annotatedKind = element.getAttribute('data-aimd-unit-kind');
     if (isReaderAtomicUnitKind(annotatedKind)) return annotatedKind;
     if (element.matches('.katex-display')) return 'display-math';
     if (element.matches('.katex')) return 'inline-math';
     if (element.matches('pre')) return 'code-block';
     if (element.matches('table')) return 'table';
-    if (element.matches('code')) return element.closest('pre') ? 'code-block' : 'inline-code';
+    if (element.matches('code')) return 'inline-code';
     if (element.matches('img')) return 'image';
     if (element.matches('li')) return 'list-item';
     if (element.matches('blockquote')) return 'blockquote';

--- a/src/services/reader/atomicSelection.ts
+++ b/src/services/reader/atomicSelection.ts
@@ -4,21 +4,27 @@ export type SelectedAtomicUnit = ReaderAtomicUnit & {
     element: HTMLElement;
 };
 
+const READER_ATOMIC_UNIT_KINDS = [
+    'inline-math',
+    'display-math',
+    'inline-code',
+    'code-block',
+    'table',
+    'image',
+    'heading',
+    'list-item',
+    'blockquote',
+    'thematic-break',
+] as const satisfies readonly ReaderAtomicUnitKind[];
+
+const READER_ATOMIC_UNIT_KIND_SET = new Set<string>(READER_ATOMIC_UNIT_KINDS);
+
 export function isTextSelectableAtomicUnitKind(kind: ReaderAtomicUnitKind): boolean {
     return kind === 'inline-code' || kind === 'code-block' || kind === 'table';
 }
 
 function isReaderAtomicUnitKind(value: string | null): value is ReaderAtomicUnitKind {
-    return value === 'inline-math'
-        || value === 'display-math'
-        || value === 'inline-code'
-        || value === 'code-block'
-        || value === 'table'
-        || value === 'image'
-        || value === 'heading'
-        || value === 'list-item'
-        || value === 'blockquote'
-        || value === 'thematic-break';
+    return Boolean(value && READER_ATOMIC_UNIT_KIND_SET.has(value));
 }
 
 function isStructuralUnitKind(kind: ReaderAtomicUnitKind | null): boolean {
@@ -151,26 +157,32 @@ export function resolveReaderSelectionRange(selection: Selection | null, shadow:
 
 export function resolveSelectedAtomicUnits(range: Range, root: HTMLElement): SelectedAtomicUnit[] {
     const selected = Array.from(root.querySelectorAll<HTMLElement>('[data-aimd-unit-id]'))
-        .filter((element) => {
-            if (!range.intersectsNode(element)) return false;
-            const kind = resolveRenderedAtomicUnitKind(element);
-            const mode = resolveRenderedAtomicUnitMode(element, kind);
-            if (mode === 'structural') return rangeCoversElementText(range, element);
-            if (kind && isTextSelectableAtomicUnitKind(kind)) return rangeCoversElementText(range, element);
-            return true;
-        })
         .map((element) => {
             const kind = resolveRenderedAtomicUnitKind(element);
+            if (!kind) return null;
             return {
-                id: element.getAttribute('data-aimd-unit-id') || '',
-                kind: (kind || '') as ReaderAtomicUnitKind,
-                mode: resolveRenderedAtomicUnitMode(element, kind),
-                start: Number(element.getAttribute('data-aimd-md-start') || 0),
-                end: Number(element.getAttribute('data-aimd-md-end') || 0),
-                source: '',
                 element,
+                kind,
+                mode: resolveRenderedAtomicUnitMode(element, kind),
             };
-        });
+        })
+        .filter((candidate): candidate is { element: HTMLElement; kind: ReaderAtomicUnitKind; mode: ReaderAtomicUnitMode } => {
+            if (!candidate) return false;
+            const { element, kind, mode } = candidate;
+            if (!range.intersectsNode(element)) return false;
+            if (mode === 'structural') return rangeCoversElementText(range, element);
+            if (isTextSelectableAtomicUnitKind(kind)) return rangeCoversElementText(range, element);
+            return true;
+        })
+        .map(({ element, kind, mode }) => ({
+            id: element.getAttribute('data-aimd-unit-id') || '',
+            kind,
+            mode,
+            start: Number(element.getAttribute('data-aimd-md-start') || 0),
+            end: Number(element.getAttribute('data-aimd-md-end') || 0),
+            source: '',
+            element,
+        }));
 
     return selected
         .filter((unit) => !selected.some((candidate) => (

--- a/src/services/reader/atomicSelection.ts
+++ b/src/services/reader/atomicSelection.ts
@@ -17,14 +17,14 @@ const READER_ATOMIC_UNIT_KINDS = [
     'thematic-break',
 ] as const satisfies readonly ReaderAtomicUnitKind[];
 
-const READER_ATOMIC_UNIT_KIND_SET = new Set<string>(READER_ATOMIC_UNIT_KINDS);
+const READER_ATOMIC_UNIT_KIND_SET = new Set<ReaderAtomicUnitKind>(READER_ATOMIC_UNIT_KINDS);
 
 export function isTextSelectableAtomicUnitKind(kind: ReaderAtomicUnitKind): boolean {
     return kind === 'inline-code' || kind === 'code-block' || kind === 'table';
 }
 
 function isReaderAtomicUnitKind(value: string | null): value is ReaderAtomicUnitKind {
-    return Boolean(value && READER_ATOMIC_UNIT_KIND_SET.has(value));
+    return Boolean(value && READER_ATOMIC_UNIT_KIND_SET.has(value as ReaderAtomicUnitKind));
 }
 
 function isStructuralUnitKind(kind: ReaderAtomicUnitKind | null): boolean {
@@ -73,14 +73,17 @@ function collectRenderedUnitElements(root: HTMLElement): Array<{ kind: ReaderAto
         })
         .sort(compareDocumentOrder);
 
-    return elements.map((element) => {
-        const kind = resolveRenderedAtomicUnitKind(element) ?? 'heading';
-        return {
-            kind,
-            mode: resolveRenderedAtomicUnitMode(element, kind),
-            element,
-        };
-    });
+    return elements
+        .map((element) => {
+            const kind = resolveRenderedAtomicUnitKind(element);
+            if (!kind) return null;
+            return {
+                kind,
+                mode: resolveRenderedAtomicUnitMode(element, kind),
+                element,
+            };
+        })
+        .filter((unit): unit is { kind: ReaderAtomicUnitKind; mode: ReaderAtomicUnitMode; element: HTMLElement } => Boolean(unit));
 }
 
 export function annotateRenderedAtomicUnits(root: HTMLElement, units: ReaderAtomicUnit[]): SelectedAtomicUnit[] {

--- a/src/services/reader/atomicSelection.ts
+++ b/src/services/reader/atomicSelection.ts
@@ -8,6 +8,48 @@ export function isTextSelectableAtomicUnitKind(kind: ReaderAtomicUnitKind): bool
     return kind === 'inline-code' || kind === 'code-block' || kind === 'table';
 }
 
+function isReaderAtomicUnitKind(value: string | null): value is ReaderAtomicUnitKind {
+    return value === 'inline-math'
+        || value === 'display-math'
+        || value === 'inline-code'
+        || value === 'code-block'
+        || value === 'table'
+        || value === 'image'
+        || value === 'heading'
+        || value === 'list-item'
+        || value === 'blockquote'
+        || value === 'thematic-break';
+}
+
+function isStructuralUnitKind(kind: ReaderAtomicUnitKind | null): boolean {
+    return kind === 'heading'
+        || kind === 'list-item'
+        || kind === 'blockquote'
+        || kind === 'thematic-break';
+}
+
+export function resolveRenderedAtomicUnitKind(element: HTMLElement): ReaderAtomicUnitKind | null {
+    const annotatedKind = element.getAttribute('data-aimd-unit-kind');
+    if (isReaderAtomicUnitKind(annotatedKind)) return annotatedKind;
+    if (element.matches('.katex-display')) return 'display-math';
+    if (element.matches('.katex')) return 'inline-math';
+    if (element.matches('pre')) return 'code-block';
+    if (element.matches('table')) return 'table';
+    if (element.matches('code')) return element.closest('pre') ? 'code-block' : 'inline-code';
+    if (element.matches('img')) return 'image';
+    if (element.matches('li')) return 'list-item';
+    if (element.matches('blockquote')) return 'blockquote';
+    if (element.matches('hr')) return 'thematic-break';
+    if (element.matches('h1, h2, h3, h4, h5, h6')) return 'heading';
+    return null;
+}
+
+function resolveRenderedAtomicUnitMode(element: HTMLElement, kind: ReaderAtomicUnitKind | null): ReaderAtomicUnitMode {
+    const mode = element.getAttribute('data-aimd-unit-mode');
+    if (mode === 'atomic' || mode === 'structural') return mode;
+    return isStructuralUnitKind(kind) ? 'structural' : 'atomic';
+}
+
 function compareDocumentOrder(a: Element, b: Element): number {
     if (a === b) return 0;
     const relation = a.compareDocumentPosition(b);
@@ -26,16 +68,12 @@ function collectRenderedUnitElements(root: HTMLElement): Array<{ kind: ReaderAto
         .sort(compareDocumentOrder);
 
     return elements.map((element) => {
-        if (element.matches('.katex-display')) return { kind: 'display-math' as const, mode: 'atomic' as const, element };
-        if (element.matches('.katex')) return { kind: 'inline-math' as const, mode: 'atomic' as const, element };
-        if (element.matches('code')) return { kind: 'inline-code' as const, mode: 'atomic' as const, element };
-        if (element.matches('pre')) return { kind: 'code-block' as const, mode: 'atomic' as const, element };
-        if (element.matches('img')) return { kind: 'image' as const, mode: 'atomic' as const, element };
-        if (element.matches('table')) return { kind: 'table' as const, mode: 'atomic' as const, element };
-        if (element.matches('li')) return { kind: 'list-item' as const, mode: 'structural' as const, element };
-        if (element.matches('blockquote')) return { kind: 'blockquote' as const, mode: 'structural' as const, element };
-        if (element.matches('hr')) return { kind: 'thematic-break' as const, mode: 'structural' as const, element };
-        return { kind: 'heading' as const, mode: 'structural' as const, element };
+        const kind = resolveRenderedAtomicUnitKind(element) ?? 'heading';
+        return {
+            kind,
+            mode: resolveRenderedAtomicUnitMode(element, kind),
+            element,
+        };
     });
 }
 
@@ -115,21 +153,24 @@ export function resolveSelectedAtomicUnits(range: Range, root: HTMLElement): Sel
     const selected = Array.from(root.querySelectorAll<HTMLElement>('[data-aimd-unit-id]'))
         .filter((element) => {
             if (!range.intersectsNode(element)) return false;
-            const kind = (element.getAttribute('data-aimd-unit-kind') || '') as ReaderAtomicUnitKind;
-            const mode = element.getAttribute('data-aimd-unit-mode') || 'atomic';
+            const kind = resolveRenderedAtomicUnitKind(element);
+            const mode = resolveRenderedAtomicUnitMode(element, kind);
             if (mode === 'structural') return rangeCoversElementText(range, element);
-            if (isTextSelectableAtomicUnitKind(kind)) return rangeCoversElementText(range, element);
+            if (kind && isTextSelectableAtomicUnitKind(kind)) return rangeCoversElementText(range, element);
             return true;
         })
-        .map((element) => ({
-            id: element.getAttribute('data-aimd-unit-id') || '',
-            kind: (element.getAttribute('data-aimd-unit-kind') || '') as ReaderAtomicUnitKind,
-            mode: (element.getAttribute('data-aimd-unit-mode') || 'atomic') as ReaderAtomicUnitMode,
-            start: Number(element.getAttribute('data-aimd-md-start') || 0),
-            end: Number(element.getAttribute('data-aimd-md-end') || 0),
-            source: '',
-            element,
-        }));
+        .map((element) => {
+            const kind = resolveRenderedAtomicUnitKind(element);
+            return {
+                id: element.getAttribute('data-aimd-unit-id') || '',
+                kind: (kind || '') as ReaderAtomicUnitKind,
+                mode: resolveRenderedAtomicUnitMode(element, kind),
+                start: Number(element.getAttribute('data-aimd-md-start') || 0),
+                end: Number(element.getAttribute('data-aimd-md-end') || 0),
+                source: '',
+                element,
+            };
+        });
 
     return selected
         .filter((unit) => !selected.some((candidate) => (

--- a/src/services/reader/atomicSelection.ts
+++ b/src/services/reader/atomicSelection.ts
@@ -4,6 +4,10 @@ export type SelectedAtomicUnit = ReaderAtomicUnit & {
     element: HTMLElement;
 };
 
+export function isTextSelectableAtomicUnitKind(kind: ReaderAtomicUnitKind): boolean {
+    return kind === 'inline-code' || kind === 'code-block' || kind === 'table';
+}
+
 function compareDocumentOrder(a: Element, b: Element): number {
     if (a === b) return 0;
     const relation = a.compareDocumentPosition(b);
@@ -111,8 +115,11 @@ export function resolveSelectedAtomicUnits(range: Range, root: HTMLElement): Sel
     const selected = Array.from(root.querySelectorAll<HTMLElement>('[data-aimd-unit-id]'))
         .filter((element) => {
             if (!range.intersectsNode(element)) return false;
+            const kind = (element.getAttribute('data-aimd-unit-kind') || '') as ReaderAtomicUnitKind;
             const mode = element.getAttribute('data-aimd-unit-mode') || 'atomic';
-            return mode === 'structural' ? rangeCoversElementText(range, element) : true;
+            if (mode === 'structural') return rangeCoversElementText(range, element);
+            if (isTextSelectableAtomicUnitKind(kind)) return rangeCoversElementText(range, element);
+            return true;
         })
         .map((element) => ({
             id: element.getAttribute('data-aimd-unit-id') || '',

--- a/src/services/reader/commentAnchoring.ts
+++ b/src/services/reader/commentAnchoring.ts
@@ -83,7 +83,7 @@ function collectVisibleText(root: HTMLElement): string {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
         acceptNode(node) {
             if (!node.textContent) return NodeFilter.FILTER_REJECT;
-            if (isExcludedAtomicTextNode(node)) return NodeFilter.FILTER_REJECT;
+            if (isNonTextSelectableUnitTextNode(node)) return NodeFilter.FILTER_REJECT;
             return NodeFilter.FILTER_ACCEPT;
         },
     });
@@ -99,7 +99,7 @@ function getTextOffset(root: HTMLElement, container: Node, localOffset: number):
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
         acceptNode(node) {
             if (!node.textContent) return NodeFilter.FILTER_REJECT;
-            if (isExcludedAtomicTextNode(node)) return NodeFilter.FILTER_REJECT;
+            if (isNonTextSelectableUnitTextNode(node)) return NodeFilter.FILTER_REJECT;
             return NodeFilter.FILTER_ACCEPT;
         },
     });
@@ -120,7 +120,7 @@ function buildTextPosition(root: HTMLElement, range: Range): ReaderCommentTextPo
     };
 }
 
-function isExcludedAtomicTextNode(node: Node): boolean {
+function isNonTextSelectableUnitTextNode(node: Node): boolean {
     const unitElement = node.parentElement?.closest<HTMLElement>('[data-aimd-unit-id]');
     if (!unitElement) return false;
     const kind = resolveRenderedAtomicUnitKind(unitElement);

--- a/src/services/reader/commentAnchoring.ts
+++ b/src/services/reader/commentAnchoring.ts
@@ -1,4 +1,4 @@
-import type { SelectedAtomicUnit } from './atomicSelection';
+import { isTextSelectableAtomicUnitKind, type SelectedAtomicUnit } from './atomicSelection';
 import { buildAtomicSelectionExport } from './atomicExport';
 import type {
     ReaderCommentAtomicRef,
@@ -83,7 +83,7 @@ function collectVisibleText(root: HTMLElement): string {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
         acceptNode(node) {
             if (!node.textContent) return NodeFilter.FILTER_REJECT;
-            if (node.parentElement?.closest('[data-aimd-unit-id]')) return NodeFilter.FILTER_REJECT;
+            if (isExcludedAtomicTextNode(node)) return NodeFilter.FILTER_REJECT;
             return NodeFilter.FILTER_ACCEPT;
         },
     });
@@ -99,7 +99,7 @@ function getTextOffset(root: HTMLElement, container: Node, localOffset: number):
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
         acceptNode(node) {
             if (!node.textContent) return NodeFilter.FILTER_REJECT;
-            if (node.parentElement?.closest('[data-aimd-unit-id]')) return NodeFilter.FILTER_REJECT;
+            if (isExcludedAtomicTextNode(node)) return NodeFilter.FILTER_REJECT;
             return NodeFilter.FILTER_ACCEPT;
         },
     });
@@ -118,6 +118,13 @@ function buildTextPosition(root: HTMLElement, range: Range): ReaderCommentTextPo
         start: getTextOffset(root, range.startContainer, range.startOffset),
         end: getTextOffset(root, range.endContainer, range.endOffset),
     };
+}
+
+function isExcludedAtomicTextNode(node: Node): boolean {
+    const unitElement = node.parentElement?.closest<HTMLElement>('[data-aimd-unit-id]');
+    if (!unitElement) return false;
+    const kind = unitElement.getAttribute('data-aimd-unit-kind');
+    return !kind || !isTextSelectableAtomicUnitKind(kind as SelectedAtomicUnit['kind']);
 }
 
 function buildTextQuote(root: HTMLElement, exact: string): ReaderCommentTextQuoteSelector {

--- a/src/services/reader/commentAnchoring.ts
+++ b/src/services/reader/commentAnchoring.ts
@@ -1,4 +1,4 @@
-import { isTextSelectableAtomicUnitKind, type SelectedAtomicUnit } from './atomicSelection';
+import { isTextSelectableAtomicUnitKind, resolveRenderedAtomicUnitKind, type SelectedAtomicUnit } from './atomicSelection';
 import { buildAtomicSelectionExport } from './atomicExport';
 import type {
     ReaderCommentAtomicRef,
@@ -123,8 +123,8 @@ function buildTextPosition(root: HTMLElement, range: Range): ReaderCommentTextPo
 function isExcludedAtomicTextNode(node: Node): boolean {
     const unitElement = node.parentElement?.closest<HTMLElement>('[data-aimd-unit-id]');
     if (!unitElement) return false;
-    const kind = unitElement.getAttribute('data-aimd-unit-kind');
-    return !kind || !isTextSelectableAtomicUnitKind(kind as SelectedAtomicUnit['kind']);
+    const kind = resolveRenderedAtomicUnitKind(unitElement);
+    return !kind || !isTextSelectableAtomicUnitKind(kind);
 }
 
 function buildTextQuote(root: HTMLElement, exact: string): ReaderCommentTextQuoteSelector {

--- a/tests/integration/reader/reader-panel.test.ts
+++ b/tests/integration/reader/reader-panel.test.ts
@@ -12,8 +12,17 @@ function setClipboardMock() {
 
 function createSelection(range: Range): Selection {
     return {
+        anchorNode: range.startContainer,
+        anchorOffset: range.startOffset,
+        focusNode: range.endContainer,
+        focusOffset: range.endOffset,
+        isCollapsed: range.collapsed,
         rangeCount: 1,
-        getRangeAt: () => range,
+        getRangeAt: (index: number) => {
+            if (index !== 0) throw new DOMException('Selection range index out of bounds.', 'IndexSizeError');
+            return range;
+        },
+        removeAllRanges: () => undefined,
         toString: () => range.toString(),
     } as unknown as Selection;
 }

--- a/tests/integration/reader/reader-panel.test.ts
+++ b/tests/integration/reader/reader-panel.test.ts
@@ -18,13 +18,23 @@ function createSelection(range: Range): Selection {
     } as unknown as Selection;
 }
 
-function installSelectionLayout(range: Range, markdownRoot: HTMLElement): void {
+function attachSelectionRangeLayout(range: Range): Range {
     Object.assign(range, {
         getClientRects: () => ([
             { left: 40, top: 40, width: 64, height: 20, right: 104, bottom: 60, x: 40, y: 40, toJSON: () => ({}) },
         ]),
-        cloneRange: () => range,
+        cloneRange: () => {
+            const clone = document.createRange();
+            clone.setStart(range.startContainer, range.startOffset);
+            clone.setEnd(range.endContainer, range.endOffset);
+            return attachSelectionRangeLayout(clone);
+        },
     });
+    return range;
+}
+
+function installSelectionLayout(range: Range, markdownRoot: HTMLElement): void {
+    attachSelectionRangeLayout(range);
     Object.assign(markdownRoot, {
         getBoundingClientRect: () => ({
             left: 0, top: 0, width: 840, height: 320, right: 840, bottom: 320, x: 0, y: 0, toJSON: () => ({}),

--- a/tests/integration/reader/reader-panel.test.ts
+++ b/tests/integration/reader/reader-panel.test.ts
@@ -10,6 +10,28 @@ function setClipboardMock() {
     return { writeText };
 }
 
+function createSelection(range: Range): Selection {
+    return {
+        rangeCount: 1,
+        getRangeAt: () => range,
+        toString: () => range.toString(),
+    } as unknown as Selection;
+}
+
+function installSelectionLayout(range: Range, markdownRoot: HTMLElement): void {
+    Object.assign(range, {
+        getClientRects: () => ([
+            { left: 40, top: 40, width: 64, height: 20, right: 104, bottom: 60, x: 40, y: 40, toJSON: () => ({}) },
+        ]),
+        cloneRange: () => range,
+    });
+    Object.assign(markdownRoot, {
+        getBoundingClientRect: () => ({
+            left: 0, top: 0, width: 840, height: 320, right: 840, bottom: 320, x: 0, y: 0, toJSON: () => ({}),
+        }),
+    });
+}
+
 async function waitFor<T>(
     read: () => T | null,
     timeoutMs: number = 200,
@@ -310,6 +332,69 @@ describe('ReaderPanel (MVP)', () => {
 
         expect(clipboardData.values.get('text/plain')).toContain('`code`');
         expect(clipboardData.values.get('text/plain')).toContain('$x+y$');
+        getSelectionSpy.mockRestore();
+    });
+
+    it('uses the exact text selected inside a fenced code block for copy, comment, and sticky actions', async () => {
+        const { writeText } = setClipboardMock();
+        const panel = new ReaderPanel();
+
+        await panel.show(
+            [{
+                id: 'a',
+                userPrompt: 'Q1',
+                content: '```ts\nconst answer = 42;\nconsole.log(answer);\n```',
+            }],
+            0,
+            'light'
+        );
+
+        const host = document.querySelector('#aimd-reader-panel-host') as HTMLElement;
+        const shadow = host.shadowRoot as ShadowRoot;
+        const markdownRoot = await waitFor(() => shadow.querySelector<HTMLElement>('.reader-markdown'));
+        await waitFor(() => markdownRoot.querySelector<HTMLElement>('.reader-code-block'));
+
+        const walker = document.createTreeWalker(markdownRoot, NodeFilter.SHOW_TEXT);
+        let answerNode: Text | null = null;
+        while (walker.nextNode()) {
+            const node = walker.currentNode as Text;
+            if (node.data.includes('answer')) {
+                answerNode = node;
+                break;
+            }
+        }
+        expect(answerNode).toBeTruthy();
+
+        const start = answerNode!.data.indexOf('answer');
+        const range = document.createRange();
+        range.setStart(answerNode!, start);
+        range.setEnd(answerNode!, start + 'answer'.length);
+        installSelectionLayout(range, markdownRoot);
+
+        const getSelectionSpy = vi.spyOn(window, 'getSelection').mockReturnValue(createSelection(range));
+        document.dispatchEvent(new Event('selectionchange'));
+        await Promise.resolve();
+
+        shadow.querySelector<HTMLButtonElement>('[data-action="reader-selection-copy"]')!.click();
+        await Promise.resolve();
+        expect(writeText).toHaveBeenLastCalledWith('answer');
+
+        shadow.querySelector<HTMLButtonElement>('[data-action="reader-comment-add"]')!.click();
+        await Promise.resolve();
+        expect(shadow.querySelector<HTMLElement>('.reader-comment-popover__selection-value')?.textContent).toBe('answer');
+        shadow.querySelector<HTMLButtonElement>('.reader-comment-popover [data-action="cancel"]')!.click();
+        await Promise.resolve();
+
+        document.dispatchEvent(new Event('selectionchange'));
+        await Promise.resolve();
+        shadow.querySelector<HTMLButtonElement>('[data-action="reader-selection-stick"]')!.click();
+        await Promise.resolve();
+
+        const stickyBlock = shadow.querySelector<HTMLElement>('.reader-sticky-block')!;
+        expect(stickyBlock.textContent).toContain('answer');
+        expect(stickyBlock.textContent).not.toContain('console.log');
+        expect(stickyBlock.querySelector('pre')).toBeNull();
+
         getSelectionSpy.mockRestore();
     });
 

--- a/tests/unit/services/reader/atomicExport.test.ts
+++ b/tests/unit/services/reader/atomicExport.test.ts
@@ -132,6 +132,41 @@ describe('atomicExport', () => {
         expect(exportText).toBe('```ts\nconst answer = 42;\n```');
     });
 
+    it('suppresses text inside nested units when an ancestor unit is selected', () => {
+        const root = document.createElement('div');
+        root.innerHTML = `
+          <div class="reader-markdown">
+            <blockquote data-aimd-unit-id="quote1" data-aimd-unit-kind="blockquote" data-aimd-unit-mode="structural">
+              Before <code data-aimd-unit-id="code1" data-aimd-unit-kind="inline-code" data-aimd-unit-mode="atomic">answer</code> after
+            </blockquote>
+          </div>
+        `;
+        const quote = root.querySelector('blockquote') as HTMLElement;
+        const beforeText = quote.firstChild as Text;
+        const afterText = quote.lastChild as Text;
+        const range = document.createRange();
+        range.setStart(beforeText, 0);
+        range.setEnd(afterText, afterText.textContent!.length);
+
+        const exportText = buildAtomicSelectionExport({
+            range,
+            root,
+            selectedUnits: [
+                {
+                    id: 'quote1',
+                    kind: 'blockquote',
+                    mode: 'structural',
+                    source: '> Before `answer` after',
+                    start: 0,
+                    end: 23,
+                    element: quote,
+                },
+            ],
+        });
+
+        expect(exportText).toBe('> Before `answer` after');
+    });
+
     it('exports fully selected structural units as markdown source', () => {
         const root = document.createElement('div');
         root.innerHTML = `

--- a/tests/unit/services/reader/atomicExport.test.ts
+++ b/tests/unit/services/reader/atomicExport.test.ts
@@ -71,7 +71,7 @@ describe('atomicExport', () => {
         const root = document.createElement('div');
         root.innerHTML = `
           <div class="reader-markdown">
-            <p><code data-aimd-unit-id="code1">answer</code> and <span data-aimd-unit-id="math1">x+y</span></p>
+            <p><code data-aimd-unit-id="code1" data-aimd-unit-kind="inline-code" data-aimd-unit-mode="atomic">answer</code> and <span data-aimd-unit-id="math1" data-aimd-unit-kind="inline-math" data-aimd-unit-mode="atomic">x+y</span></p>
           </div>
         `;
         const paragraph = root.querySelector('p')!;
@@ -104,7 +104,7 @@ describe('atomicExport', () => {
         const root = document.createElement('div');
         root.innerHTML = `
           <div class="reader-markdown">
-            <pre data-aimd-unit-id="code1"><code>const answer = 42;</code></pre>
+            <pre data-aimd-unit-id="code1" data-aimd-unit-kind="code-block" data-aimd-unit-mode="atomic"><code>const answer = 42;</code></pre>
           </div>
         `;
         const codeText = root.querySelector('code')!.firstChild as Text;

--- a/tests/unit/services/reader/atomicExport.test.ts
+++ b/tests/unit/services/reader/atomicExport.test.ts
@@ -67,6 +67,71 @@ describe('atomicExport', () => {
         expect(exportText).toBe('ading');
     });
 
+    it('keeps selected text inside an unselected text-selectable atomic unit', () => {
+        const root = document.createElement('div');
+        root.innerHTML = `
+          <div class="reader-markdown">
+            <p><code data-aimd-unit-id="code1">answer</code> and <span data-aimd-unit-id="math1">x+y</span></p>
+          </div>
+        `;
+        const paragraph = root.querySelector('p')!;
+        const codeText = paragraph.querySelector('code')!.firstChild as Text;
+        const mathText = paragraph.querySelector('[data-aimd-unit-id="math1"]')!.firstChild as Text;
+        const range = document.createRange();
+        range.setStart(codeText, 0);
+        range.setEnd(mathText, mathText.textContent!.length);
+
+        const exportText = buildAtomicSelectionExport({
+            range,
+            root,
+            selectedUnits: [
+                {
+                    id: 'math1',
+                    kind: 'inline-math',
+                    mode: 'atomic',
+                    source: '$x+y$',
+                    start: 18,
+                    end: 23,
+                    element: paragraph.querySelector('[data-aimd-unit-id="math1"]') as HTMLElement,
+                },
+            ],
+        });
+
+        expect(exportText).toBe('answer and $x+y$');
+    });
+
+    it('exports a fully selected code block as fenced markdown source', () => {
+        const root = document.createElement('div');
+        root.innerHTML = `
+          <div class="reader-markdown">
+            <pre data-aimd-unit-id="code1"><code>const answer = 42;</code></pre>
+          </div>
+        `;
+        const codeText = root.querySelector('code')!.firstChild as Text;
+        const codeBlock = root.querySelector('pre') as HTMLElement;
+        const range = document.createRange();
+        range.setStart(codeText, 0);
+        range.setEnd(codeText, codeText.data.length);
+
+        const exportText = buildAtomicSelectionExport({
+            range,
+            root,
+            selectedUnits: [
+                {
+                    id: 'code1',
+                    kind: 'code-block',
+                    mode: 'atomic',
+                    source: '```ts\nconst answer = 42;\n```',
+                    start: 0,
+                    end: 29,
+                    element: codeBlock,
+                },
+            ],
+        });
+
+        expect(exportText).toBe('```ts\nconst answer = 42;\n```');
+    });
+
     it('exports fully selected structural units as markdown source', () => {
         const root = document.createElement('div');
         root.innerHTML = `

--- a/tests/unit/services/reader/atomicSelection.test.ts
+++ b/tests/unit/services/reader/atomicSelection.test.ts
@@ -196,6 +196,25 @@ console.log(answer);</code></pre>
         expect(resolveSelectedAtomicUnits(full, root).map((unit) => unit.kind)).toEqual(['code-block']);
     });
 
+    it('does not collect nested code elements inside a selected code block', () => {
+        const root = document.createElement('div');
+        root.innerHTML = `
+          <div class="reader-markdown">
+            <pre data-aimd-unit-id="outer" data-aimd-unit-kind="code-block" data-aimd-unit-mode="atomic" data-aimd-md-start="0" data-aimd-md-end="44"><code data-aimd-unit-id="inner" data-aimd-unit-kind="code-block" data-aimd-unit-mode="atomic" data-aimd-md-start="0" data-aimd-md-end="44">const answer = 42;</code></pre>
+          </div>
+        `;
+
+        const codeText = root.querySelector('code')!.firstChild as Text;
+        const full = document.createRange();
+        full.setStart(codeText, 0);
+        full.setEnd(codeText, codeText.data.length);
+
+        const selected = resolveSelectedAtomicUnits(full, root);
+
+        expect(selected.map((unit) => unit.id)).toEqual(['outer']);
+        expect(selected.map((unit) => unit.kind)).toEqual(['code-block']);
+    });
+
     it('keeps partial table selections as text and full table selections as atomic source', () => {
         const root = document.createElement('div');
         root.innerHTML = `

--- a/tests/unit/services/reader/atomicSelection.test.ts
+++ b/tests/unit/services/reader/atomicSelection.test.ts
@@ -196,6 +196,31 @@ console.log(answer);</code></pre>
         expect(resolveSelectedAtomicUnits(full, root).map((unit) => unit.kind)).toEqual(['code-block']);
     });
 
+    it('keeps partial table selections as text and full table selections as atomic source', () => {
+        const root = document.createElement('div');
+        root.innerHTML = `
+          <div class="reader-markdown">
+            <table data-aimd-unit-id="table1" data-aimd-unit-kind="table" data-aimd-unit-mode="atomic" data-aimd-md-start="0" data-aimd-md-end="32">
+              <tbody><tr><td>Alpha</td><td>Beta</td></tr></tbody>
+            </table>
+          </div>
+        `;
+
+        const firstCellText = root.querySelector('td')!.firstChild as Text;
+        const partial = document.createRange();
+        partial.setStart(firstCellText, 1);
+        partial.setEnd(firstCellText, firstCellText.data.length);
+
+        expect(resolveSelectedAtomicUnits(partial, root)).toHaveLength(0);
+
+        const lastCellText = root.querySelectorAll('td')[1]!.firstChild as Text;
+        const full = document.createRange();
+        full.setStart(firstCellText, 0);
+        full.setEnd(lastCellText, lastCellText.data.length);
+
+        expect(resolveSelectedAtomicUnits(full, root).map((unit) => unit.kind)).toEqual(['table']);
+    });
+
     it('ignores unclassified unit metadata instead of returning invalid unit kinds', () => {
         const root = document.createElement('div');
         root.innerHTML = `

--- a/tests/unit/services/reader/atomicSelection.test.ts
+++ b/tests/unit/services/reader/atomicSelection.test.ts
@@ -173,6 +173,29 @@ console.log(answer);</code></pre>
         expect(resolveSelectedAtomicUnits(full, root).map((unit) => unit.kind)).toEqual(['code-block']);
     });
 
+    it('infers text-selectable code blocks when unit kind metadata is missing', () => {
+        const root = document.createElement('div');
+        root.innerHTML = `
+          <div class="reader-markdown">
+            <pre data-aimd-unit-id="u1" data-aimd-md-start="0" data-aimd-md-end="44"><code>const answer = 42;
+console.log(answer);</code></pre>
+          </div>
+        `;
+
+        const codeText = root.querySelector('code')!.firstChild as Text;
+        const partial = document.createRange();
+        partial.setStart(codeText, 6);
+        partial.setEnd(codeText, 12);
+
+        expect(resolveSelectedAtomicUnits(partial, root)).toHaveLength(0);
+
+        const full = document.createRange();
+        full.setStart(codeText, 0);
+        full.setEnd(codeText, codeText.data.length);
+
+        expect(resolveSelectedAtomicUnits(full, root).map((unit) => unit.kind)).toEqual(['code-block']);
+    });
+
     it('rejects selections whose endpoints are not both inside the reader markdown root', () => {
         const host = document.createElement('div');
         const shadow = host.attachShadow({ mode: 'open' });

--- a/tests/unit/services/reader/atomicSelection.test.ts
+++ b/tests/unit/services/reader/atomicSelection.test.ts
@@ -128,6 +128,51 @@ describe('atomicSelection', () => {
         expect(resolveSelectedAtomicUnits(range, root)).toHaveLength(0);
     });
 
+    it('keeps partial inline code selections as plain text slices', () => {
+        const root = document.createElement('div');
+        root.innerHTML = `
+          <div class="reader-markdown">
+            <p>Before <code data-aimd-unit-id="u1" data-aimd-unit-kind="inline-code" data-aimd-unit-mode="atomic" data-aimd-md-start="7" data-aimd-md-end="20">code sample</code> after</p>
+          </div>
+        `;
+
+        const codeText = root.querySelector('code')!.firstChild as Text;
+        const partial = document.createRange();
+        partial.setStart(codeText, 2);
+        partial.setEnd(codeText, 6);
+
+        expect(resolveSelectedAtomicUnits(partial, root)).toHaveLength(0);
+
+        const full = document.createRange();
+        full.setStart(codeText, 0);
+        full.setEnd(codeText, codeText.data.length);
+
+        expect(resolveSelectedAtomicUnits(full, root).map((unit) => unit.kind)).toEqual(['inline-code']);
+    });
+
+    it('keeps partial fenced code block selections as plain text slices', () => {
+        const root = document.createElement('div');
+        root.innerHTML = `
+          <div class="reader-markdown">
+            <pre data-aimd-unit-id="u1" data-aimd-unit-kind="code-block" data-aimd-unit-mode="atomic" data-aimd-md-start="0" data-aimd-md-end="44"><code>const answer = 42;
+console.log(answer);</code></pre>
+          </div>
+        `;
+
+        const codeText = root.querySelector('code')!.firstChild as Text;
+        const partial = document.createRange();
+        partial.setStart(codeText, 6);
+        partial.setEnd(codeText, 12);
+
+        expect(resolveSelectedAtomicUnits(partial, root)).toHaveLength(0);
+
+        const full = document.createRange();
+        full.setStart(codeText, 0);
+        full.setEnd(codeText, codeText.data.length);
+
+        expect(resolveSelectedAtomicUnits(full, root).map((unit) => unit.kind)).toEqual(['code-block']);
+    });
+
     it('rejects selections whose endpoints are not both inside the reader markdown root', () => {
         const host = document.createElement('div');
         const shadow = host.attachShadow({ mode: 'open' });

--- a/tests/unit/services/reader/atomicSelection.test.ts
+++ b/tests/unit/services/reader/atomicSelection.test.ts
@@ -196,6 +196,22 @@ console.log(answer);</code></pre>
         expect(resolveSelectedAtomicUnits(full, root).map((unit) => unit.kind)).toEqual(['code-block']);
     });
 
+    it('ignores unclassified unit metadata instead of returning invalid unit kinds', () => {
+        const root = document.createElement('div');
+        root.innerHTML = `
+          <div class="reader-markdown">
+            <span data-aimd-unit-id="unknown">Unknown unit</span>
+          </div>
+        `;
+
+        const text = root.querySelector('span')!.firstChild as Text;
+        const range = document.createRange();
+        range.setStart(text, 0);
+        range.setEnd(text, text.data.length);
+
+        expect(resolveSelectedAtomicUnits(range, root)).toHaveLength(0);
+    });
+
     it('rejects selections whose endpoints are not both inside the reader markdown root', () => {
         const host = document.createElement('div');
         const shadow = host.attachShadow({ mode: 'open' });

--- a/tests/unit/services/reader/commentAnchoring.test.ts
+++ b/tests/unit/services/reader/commentAnchoring.test.ts
@@ -56,7 +56,7 @@ describe('commentAnchoring', () => {
     it('captures text selectors for partial code selections without atomic refs', () => {
         document.body.innerHTML = `
           <div id="root">
-            <pre data-aimd-unit-id="u1" data-aimd-unit-kind="code-block" data-aimd-unit-mode="atomic"><code>const answer = 42;</code></pre>
+            <pre data-aimd-unit-id="u1"><code>const answer = 42;</code></pre>
           </div>
         `;
 

--- a/tests/unit/services/reader/commentAnchoring.test.ts
+++ b/tests/unit/services/reader/commentAnchoring.test.ts
@@ -53,6 +53,37 @@ describe('commentAnchoring', () => {
         expect(resolved.units.map((unit) => unit.kind)).toEqual(['inline-code']);
     });
 
+    it('captures text selectors for partial code selections without atomic refs', () => {
+        document.body.innerHTML = `
+          <div id="root">
+            <pre data-aimd-unit-id="u1" data-aimd-unit-kind="code-block" data-aimd-unit-mode="atomic"><code>const answer = 42;</code></pre>
+          </div>
+        `;
+
+        const root = document.querySelector<HTMLElement>('#root')!;
+        const codeText = root.querySelector('code')!.firstChild as Text;
+        const start = codeText.data.indexOf('answer');
+        const range = document.createRange();
+        range.setStart(codeText, start);
+        range.setEnd(codeText, start + 'answer'.length);
+
+        const record = createReaderCommentRecord({
+            id: 'c1',
+            itemId: 'item-1',
+            comment: 'note',
+            range,
+            root,
+            selectedUnits: [],
+        });
+
+        expect(record.quoteText).toBe('answer');
+        expect(record.sourceMarkdown).toBe('answer');
+        expect(record.selectors.atomicRefs).toHaveLength(0);
+        expect(record.selectors.textQuote.exact).toBe('answer');
+        expect(record.selectors.textPosition.start).not.toBeNull();
+        expect(record.selectors.textPosition.end).not.toBeNull();
+    });
+
     it('computes overlay rectangles from a selection layout', () => {
         document.body.innerHTML = `<div id="root"><p>Alpha beta gamma</p></div>`;
         const root = document.querySelector<HTMLElement>('#root')!;


### PR DESCRIPTION
## 背景

Closes #14。

Reader 里对 Markdown closed unit 的选择处理过于粗：代码块、inline code、表格等只要与选区相交，就会被当作整个 atomic unit 选中。因此用户在代码块内部只选中一小段文字时，「注释」「复制」「Pin」都会拿到整个 Markdown block。

## 修改内容

- 将 `inline-code`、`code-block`、`table` 归为可局部文本选择的 Markdown unit。
- 只有完整覆盖这些 unit 时，才保留整块 Markdown source；局部选中时按真实 range 导出文本。
- 调整 Reader 注释锚点的 text quote / text position 逻辑，让代码块、inline code、表格内的局部选区可以生成稳定 selector。
- 增加 Reader 真实入口测试，覆盖 code block 内选中 `answer` 后，复制、注释、sticky pin 都只消费精确选区。
- 更新 Unreleased changelog。

## 验证

```sh
npx vitest run tests/unit/services/reader/atomicSelection.test.ts tests/unit/services/reader/atomicExport.test.ts tests/unit/services/reader/commentAnchoring.test.ts tests/integration/reader/reader-panel.test.ts
npx vitest run tests/unit/ui/reader/readerPanel.atomicSelection.test.ts tests/integration/reader/reader-panel.comment.test.ts tests/integration/reader/reader-panel.sticky.test.ts
git diff --check
npm run build
```

本地 Chrome/Edge 测试包已验证：在 `latex` code block 内只选中 `section defines` 后，注释弹窗的 Selected Content 只显示精确选区，不再扩展成整个 fenced code block。